### PR TITLE
layer.conf: fix layer name and define layerseries compat

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -1,5 +1,7 @@
 BBFILES += "${LAYERDIR}/recipes/*/*.bb ${LAYERDIR}/recipes/*/*.bbappend ${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 BBPATH .= ":${LAYERDIR}"
-BBFILE_COLLECTIONS += "args"
-BBFILE_PRIORITY_args = "17"
-BBFILE_PATTERN_args := "^${LAYERDIR}/"
+BBFILE_COLLECTIONS += "meta-audioreach"
+BBFILE_PRIORITY_meta-audioreach = "17"
+BBFILE_PATTERN_meta-audioreach := "^${LAYERDIR}/"
+
+LAYERSERIES_COMPAT_meta-audioreach = "kirkstone scarthgap"


### PR DESCRIPTION
Fix layer name from args to meta-audioreach and also define a layerseries compat, required for proper OE/Yocto compatibility check.