### PR TITLE
recipes: Update audioreach-conf change ID

### DIFF
--- a/recipes/audioreach-conf/audioreach-conf_git.bb
+++ b/recipes/audioreach-conf/audioreach-conf_git.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/Audioreach/audioreach-conf"
 LICENSE = "BSD-3-Clause-Clear"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=51110a366f598bc0b8f8e59141a18efb"
 
-SRCREV = "f6648f6d5cf5087708ccc59edcb1e3fc12d00f83"
+SRCREV = "8c3bfc1ff7c5b65014a33438e34c9fb180c9e7df"
 PV = "1.0+git${SRCPV}"
 
 SRC_URI = "git://github.com/Audioreach/audioreach-conf.git;protocol=https;branch=master"


### PR DESCRIPTION
Update default change ID for audioreach-conf to the latest change from the audioreach-conf repository.