### PR TITLE
recipes: Update audioreach-conf change ID

### DIFF
--- a/recipes/audioreach-conf/audioreach-conf_git.bb
+++ b/recipes/audioreach-conf/audioreach-conf_git.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/Audioreach/audioreach-conf"
 LICENSE = "BSD-3-Clause-Clear"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=51110a366f598bc0b8f8e59141a18efb"
 
-SRCREV = "39b822fffd30c4ff1219b799f14858b3a8c72f7e"
+SRCREV = "49b66340ade875d477572f223d1d9f84c69d454c"
 PV = "1.0+git${SRCPV}"
 
 SRC_URI = "git://github.com/Audioreach/audioreach-conf.git;protocol=https;branch=master"


### PR DESCRIPTION
Update the audioreach-conf change ID in the build recipe so that it will take the latest change, which will add the device PP subgraph to the default Linux use case.