### PR TITLE
audioreach-kernel: Update recipe file

### DIFF
--- a/recipes/audioreach-kernel/audioreach-kernel_git.bb
+++ b/recipes/audioreach-kernel/audioreach-kernel_git.bb
@@ -1,8 +1,10 @@
 inherit module
 
-DESCRIPTION = "AudioReach drivers"
+SUMMARY = "Qualcomm AudioReach kernel module"
+DESCRIPTION = "This module is designed for integration with the AudioReach framework, \
+allowing flexible deployment of audio algorithms and efficient hardware utilization."
 LICENSE = "GPL-2.0-only"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=0a5a2ad232bafb6974f9a29d1ba0f488"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=d683615f65309f6c050cbd1bb2b3c575"
 
 SRCREV = "${AUTOREV}"
 PV = "1.0+git${SRCPV}"
@@ -10,7 +12,16 @@ SRC_URI = "git://git@github.com/Audioreach/audioreach-kernel.git;protocol=https;
 
 S = "${WORKDIR}/git"
 
+MAKE_TARGETS = "modules"
+
+MODULES_MODULE_SYMVERS_LOCATION = "audioreach-driver"
+
+EXTRA_OEMAKE:append:qcom = " VENDOR_QCOM=1"
+
 do_install:append() {
     install -d ${D}${includedir}/linux
     cp -fr ${S}/include/uapi/linux/* ${D}${includedir}/linux
 }
+
+COMPATIBLE_MACHINE = "^$"
+COMPATIBLE_MACHINE:aarch64 = "(.*)"


### PR DESCRIPTION
Update the scarthgap recipe file to make it compatible with the latest version of audioreach-kernel.