### PR TITLE
Add test filtering, test flags, meta-security layer and publish test summaries

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -1,0 +1,253 @@
+name: 'LAVA Test Submit'
+description: 'Generate and submit LAVA test jobs using lava-test-plans'
+
+inputs:
+  # Build matrix item
+  image_name:
+    description: 'Image name for the build'
+    required: true
+  machine_name:
+    description: 'Machine name for the build'
+    required: true
+  
+  # Build URL
+  build_url:
+    description: 'Presigned URL for the build artifact'
+    required: true
+  
+  # LAVA configuration
+  distro_name:
+    description: 'Distribution name for lava-test-plans'
+    required: false
+    default: 'qcom-distro'
+  kernel:
+    description: 'Extra path suffix for kernel (e.g., -6.18)'
+    required: false
+    default: ''
+  testplan:
+    description: 'Test plan name to use in job generation'
+    required: false
+    default: 'pre-merge'
+  prefix:
+    description: 'Prefix for the compressed artifact with generated jobs'
+    required: false
+    default: 'testjobs'
+  
+  # LAVA server credentials
+  lava_token:
+    description: 'LAVA authentication token'
+    required: true
+  lava_url:
+    description: 'LAVA server URL'
+    required: false
+    default: 'lava.infra.foundries.io'
+  
+  # Job submission options
+  wait_for_job:
+    description: 'Wait for LAVA job to complete'
+    required: false
+    default: 'true'
+  fail_action_on_failure:
+    description: 'Fail action if LAVA job fails'
+    required: false
+    default: 'false'
+  
+  # GitHub context
+  run_id:
+    description: 'GitHub run ID'
+    required: true
+  run_attempt:
+    description: 'GitHub run attempt'
+    required: true
+
+outputs:
+  jobs_path:
+    description: 'Path to generated LAVA job files'
+    value: ${{ steps.generate-jobs.outputs.jobs_path }}
+  first_job:
+    description: 'Path to the first generated job file'
+    value: ${{ steps.generate-jobs.outputs.first_job }}
+  artifact_name:
+    description: 'Name of the uploaded artifact'
+    value: ${{ steps.generate-jobs.outputs.artifact_name }}
+  lava_job_id:
+    description: 'LAVA job ID (if submitted)'
+    value: ${{ steps.submit-job.outputs.job_id }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout lava-test-plans
+      uses: actions/checkout@v5
+      with:
+        repository: qualcomm-linux-stg/lava-test-plans
+        path: lava-test-plans
+        ref: master
+
+    - name: Setup Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
+
+    - name: Generate LAVA test jobs
+      id: generate-jobs
+      shell: bash
+      env:
+        DISTRO_NAME: ${{ inputs.distro_name }}
+        TESTPLAN_INPUT: ${{ inputs.testplan }}
+        IMAGE_NAME: ${{ inputs.image_name }}
+        MACHINE_NAME: ${{ inputs.machine_name }}
+        BUILD_URL: ${{ inputs.build_url }}
+        RUN_ID: ${{ inputs.run_id }}
+        RUN_ATTEMPT: ${{ inputs.run_attempt }}
+        PREFIX: ${{ inputs.prefix }}
+      run: |
+        set -euo pipefail
+        cd lava-test-plans && pip install .
+        pip install requests urllib3
+        lava-test-plans --version
+        cd "${GITHUB_WORKSPACE}"
+
+        OUT_PATH="${GITHUB_WORKSPACE}/out"
+        VARS_OUT_PATH="${OUT_PATH}/vars"
+        JOBS_OUT_PATH="${OUT_PATH}/jobs"
+        echo "jobs_path=${JOBS_OUT_PATH}" >> "$GITHUB_OUTPUT"
+        mkdir -p "${VARS_OUT_PATH}" "${JOBS_OUT_PATH}"
+
+        # === Plan roots as in the installed package ===
+        PROJECT="meta-qcom"
+
+        # Map testplan input to a plan directory
+        case "$TESTPLAN_INPUT" in
+          boot)  TESTPLAN_DIR="boot" ;;
+          pre-merge|pre-merge-basic|pre-merge-bt) TESTPLAN_DIR="pre-merge" ;;
+          *)     TESTPLAN_DIR="$TESTPLAN_INPUT" ;;
+        esac
+
+        echo "Using lava-test-plans project: ${PROJECT}"
+        echo "Resolved: MACHINE=${MACHINE_NAME}, DISTRO_NAME=${DISTRO_NAME}, TESTPLAN_DIR=${TESTPLAN_DIR}"
+
+        TESTPLAN_DIR_ABS="lava-test-plans/lava_test_plans/testplans/${PROJECT}/${DISTRO_NAME}/${TESTPLAN_DIR}"
+        if [ ! -d "${TESTPLAN_DIR_ABS}" ]; then
+          echo "ERROR: Test plan directory not found: ${TESTPLAN_DIR_ABS}"
+          ls -al "lava-test-plans/lava_test_plans/testplans/${PROJECT}/${DISTRO_NAME}" || true
+          exit 1
+        fi
+
+        # Create variables file
+        {
+          echo "PROJECT_NAME=${PROJECT}"
+          echo "PROJECT=projects/${PROJECT}/"
+          echo "LAVA_JOB_PRIORITY=50"
+          echo "OS_INFO=qcom-distro"
+          echo "BUILD_NUMBER=${RUN_ID}-${RUN_ATTEMPT}"
+          echo "DOCKER_IMAGE_POSTPROCESS=ghcr.io/foundriesio/lava-lmp-sign:main"
+          echo "AUTH_HEADER_NAME=Authentication"
+          echo "AUTH_HEADER_TOKEN=Q_GITHUB_TOKEN"
+          echo "TEST_DEFINITIONS_REPOSITORY=https://github.com/qualcomm-linux/qcom-linux-testkit/"
+          echo "FLASHER_DEVICE_TYPE=qcs"
+        } >> "${VARS_OUT_PATH}/gh-variables.ini"
+
+        IMAGE_TYPE="core-image-base"
+        if [ "${DISTRO_NAME}" = "qcom-distro" ]; then
+          IMAGE_TYPE="qcom-multimedia-image"
+          echo "AUTO_LOGIN_PASSWORD_PROMPT=Password" >> "${VARS_OUT_PATH}/gh-variables.ini"
+          echo "AUTO_LOGIN_PASSWORD=oelinux123"     >> "${VARS_OUT_PATH}/gh-variables.ini"
+        fi
+        echo "IMAGE_FILE_NAME=${IMAGE_TYPE}-${IMAGE_NAME}.rootfs.qcomflash.tar.gz" >> "${VARS_OUT_PATH}/gh-variables.ini"
+
+        # Use the presigned URL as-is
+        if [ -z "${BUILD_URL}" ]; then
+          echo "BUILD_URL missing"
+          exit 1
+        fi
+        echo "BUILD_DOWNLOAD_URL=${BUILD_URL}" >> "${VARS_OUT_PATH}/gh-variables.ini"
+        echo "ROOTFS_URL=${BUILD_URL}" >> "${VARS_OUT_PATH}/gh-variables.ini"
+        echo "DEVICE_TYPE=${IMAGE_NAME}" >> "${VARS_OUT_PATH}/gh-variables.ini"
+
+        echo "==== gh-variables.ini ===="
+        cat "${VARS_OUT_PATH}/gh-variables.ini"
+
+        # Generate jobs
+        lava-test-plans \
+          --dry-run \
+          --variables "${VARS_OUT_PATH}/gh-variables.ini" \
+          --test-plan "${PROJECT}/${DISTRO_NAME}/${TESTPLAN_DIR}" \
+          --device-type "projects/${PROJECT}/devices/${MACHINE_NAME}" \
+          --dry-run-path "${JOBS_OUT_PATH}/${IMAGE_NAME}-${DISTRO_NAME}-${TESTPLAN_DIR}" || true
+
+        # Expose the subdir where jobs were generated
+        JOBS_SUBDIR="${JOBS_OUT_PATH}/${IMAGE_NAME}-${DISTRO_NAME}-${TESTPLAN_DIR}"
+
+        # Find the first YAML job
+        FIRST_JOB=$(find "${JOBS_SUBDIR}" -type f -name '*.yaml' | sort | head -n 1 || true)
+        echo "first_job=${FIRST_JOB:-}" >> "$GITHUB_OUTPUT"
+        if [ -z "${FIRST_JOB:-}" ]; then
+          echo "WARNING: No YAMLs generated by lava-test-plans in ${JOBS_SUBDIR}"
+        else
+          echo "First generated job: ${FIRST_JOB}"
+        fi
+
+        # Artifact name for upload
+        ARTIFACT_NAME="${PREFIX}-${IMAGE_NAME}-${DISTRO_NAME}"
+        echo "artifact_name=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
+
+    - name: List generated files
+      shell: bash
+      env:
+        JOBS_PATH: ${{ steps.generate-jobs.outputs.jobs_path }}
+      run: |
+        echo "Generated LAVA test jobs:"
+        ls -R "$JOBS_PATH"
+
+    - name: Upload test jobs artifact
+      uses: actions/upload-artifact@v6
+      with:
+        name: ${{ steps.generate-jobs.outputs.artifact_name }}
+        path: ${{ steps.generate-jobs.outputs.jobs_path }}/**
+
+    - name: Submit first job to LAVA
+      id: submit-job
+      if: ${{ steps.generate-jobs.outputs.first_job != '' }}
+      uses: foundriesio/lava-action@v9
+      with:
+        lava_token: ${{ inputs.lava_token }}
+        lava_url: ${{ inputs.lava_url }}
+        job_definition: ${{ steps.generate-jobs.outputs.first_job }}
+        wait_for_job: ${{ inputs.wait_for_job }}
+        fail_action_on_failure: ${{ inputs.fail_action_on_failure }}
+        save_result_as_artifact: true
+        save_job_details: true
+        result_file_name: ${{ inputs.image_name }}
+
+    - name: Update summary
+      if: always()
+      shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image_name }}
+        MACHINE_NAME: ${{ inputs.machine_name }}
+        TESTPLAN: ${{ inputs.testplan }}
+        OUTCOME: ${{ steps.submit-job.outcome }}
+        FIRST_JOB: ${{ steps.generate-jobs.outputs.first_job }}
+      run: |
+        OUTCOME="${OUTCOME:-skipped}"
+
+        echo "## LAVA Test Job Summary" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "**Image:** \`$IMAGE_NAME\`" >> "$GITHUB_STEP_SUMMARY"
+        echo "**Machine:** \`$MACHINE_NAME\`" >> "$GITHUB_STEP_SUMMARY"
+        echo "**Test Plan:** \`$TESTPLAN\`" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        
+        if [ "$OUTCOME" = "success" ]; then
+          echo ":heavy_check_mark: LAVA job submitted successfully" >> "$GITHUB_STEP_SUMMARY"
+        elif [ "$OUTCOME" = "skipped" ]; then
+          echo ":warning: LAVA job submission was skipped (no jobs generated)" >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo ":x: LAVA job submission failed" >> "$GITHUB_STEP_SUMMARY"
+        fi
+        
+        if [ -n "$FIRST_JOB" ]; then
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Submitted Job:** \`$FIRST_JOB\`" >> "$GITHUB_STEP_SUMMARY"
+        fi

--- a/.github/actions/loading/action.yml
+++ b/.github/actions/loading/action.yml
@@ -59,16 +59,19 @@ runs:
               //get image_name
               const image = obj.image_name;
 
+              // get test_enabled
+              const testing_enabled = obj.testing_enabled
+
               if (!kas || typeof kas !== 'string') return;
 
               const kas_basename = kas.replace(/^.*\//, '').replace(/\.yml$/, '');
-              out.push({ selector, kas_file: kas, kas_basename, machine_name: machine,image_name:image });
+              out.push({ selector, kas_file: kas, kas_basename, machine_name: machine,image_name:image,testing_enabled:testing_enabled });
             };
 
             if (typeof value === 'string') {
               const kas = value;
               const kas_basename = kas.replace(/^.*\//, '').replace(/\.yml$/, '');
-              out.push({ selector, kas_file: kas, kas_basename, machine_name: selector, image_name:image });
+              out.push({ selector, kas_file: kas, kas_basename, machine_name: selector, image_name:image, testing_enabled:testing_enabled });
             } else if (Array.isArray(value)) {
               value.forEach(v => pushItem(v));
             } else if (typeof value === 'object' && value) {
@@ -110,8 +113,8 @@ runs:
       shell: bash
       run: |
         echo "## Build Matrix" >> "$GITHUB_STEP_SUMMARY"
-        echo "| Selector | Machine Name | KAS File | KAS Basename | IMAGE_NAME|" >> "$GITHUB_STEP_SUMMARY"
-        echo "|---------|--------------|----------|--------------|--------------|" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Selector | Machine Name | KAS File | KAS Basename | IMAGE_NAME| TEST_ENABLED |" >> "$GITHUB_STEP_SUMMARY"
+        echo "|---------|--------------|----------|--------------|--------------|------------|" >> "$GITHUB_STEP_SUMMARY"
 
         build_matrix='${{ steps.set-matrix.outputs.build_matrix }}'
 
@@ -121,6 +124,7 @@ runs:
           kas_file=$(echo "$entry" | jq -r '.kas_file')
           kas_basename=$(echo "$entry" | jq -r '.kas_basename')
           image_name=$(echo "$entry" | jq -r '.image_name')
+          testing_enabled=$(echo "$entry" | jq -r '.testing_enabled')
 
-          echo "| ${selector} | ${machine_name} | ${kas_file} | ${kas_basename} | ${image_name}|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| ${selector} | ${machine_name} | ${kas_file} | ${kas_basename} | ${image_name}| ${testing_enabled} |" >> "$GITHUB_STEP_SUMMARY"
         done

--- a/.github/actions/test-job-summary/action.yml
+++ b/.github/actions/test-job-summary/action.yml
@@ -1,0 +1,280 @@
+name: LAVA test job summary
+description: "Download LAVA job artifacts, build a Markdown summary, and upload it as a workflow artifact"
+inputs:
+  build_id:
+    description: "ID of the workflow from which build URL will be downloaded"
+    required: true
+  gh_token:
+    description: "Github token. It's required to download artifacts from the workflow"
+    required: true
+  prefix:
+    description: "Prefix for the compressed file that is uploaded as workflow artifact"
+    default: test-job
+  summary_file_name:
+    description: "File name that is used to save test job summary"
+    default: step-summary.txt
+outputs:
+  artifact_id:
+    description: "ID of the uploaded artifact"
+    value: ${{ steps.upload-summary.outputs.artifact-id }}
+runs:
+  using: "composite"
+
+  steps:
+      
+      - name: Download Artifacts
+        uses: actions/download-artifact@v6
+        with:
+          github-token: ${{ inputs.gh_token }}
+          run-id: ${{ inputs.build_id }}
+          path: artifacts
+          pattern: test-job*
+          merge-multiple: true
+
+      - name: "List files"
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "$GITHUB_WORKSPACE"
+          ls -R "$GITHUB_WORKSPACE"
+
+      - name: Publish Test Job Details
+        shell: bash
+        env:
+          PREFIX: ${{ inputs.prefix }}
+          SUMMARY_FILE: ${{ inputs.summary_file_name }}
+        run: |
+          set -euo pipefail
+
+          echo "$GITHUB_WORKSPACE"
+          ls -lrt "$GITHUB_WORKSPACE"
+          echo "fetching test jobs"
+          python3 << 'EOF'
+          import json
+          import os
+          import sys
+          import requests
+          from collections import defaultdict
+          import urllib3
+          
+          # Disable SSL warnings (kept as in your original)
+          urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+          
+          def fetch_job_details(job_id):
+              url = f"https://lava.infra.foundries.io/api/v0.2/jobs/{job_id}/"
+              try:
+                  response = requests.get(url, timeout=30, verify=False)
+                  response.raise_for_status()
+                  return response.json()
+              except Exception as e:
+                  print(f"Error fetching job {job_id}: {e}", file=sys.stderr)
+                  return None
+          
+          def fetch_job_suites(job_id):
+              url = f"https://lava.infra.foundries.io/api/v0.2/jobs/{job_id}/suites/"
+              try:
+                  response = requests.get(url, timeout=30, verify=False)
+                  response.raise_for_status()
+                  return response.json()
+              except Exception as e:
+                  print(f"Error fetching suites for job {job_id}: {e}", file=sys.stderr)
+                  return None
+          
+          def fetch_suite_tests(job_id, suite_id):
+              url = f"https://lava.infra.foundries.io/api/v0.2/jobs/{job_id}/suites/{suite_id}/tests/"
+              try:
+                  response = requests.get(url, timeout=30, verify=False)
+                  response.raise_for_status()
+                  return response.json()
+              except Exception as e:
+                  print(f"Error fetching tests for job {job_id}, suite {suite_id}: {e}", file=sys.stderr)
+                  return None
+          
+          def process_test_job(test_job_file):
+              print(f"Processing: {test_job_file}")
+              
+              with open(test_job_file, 'r') as f:
+                  job_data = json.load(f)
+              
+              job_id = job_data.get('id')
+              if not job_id:
+                  return None
+              
+              print(f"  Job ID: {job_id}")
+              
+              job_details = fetch_job_details(job_id)
+              if not job_details:
+                  return None
+              
+              job_health = job_details.get('health')
+              job_state = job_details.get('state')
+              job_device_type = job_details.get('requested_device_type')
+              job_url = f"https://lava.infra.foundries.io/results/{job_id}"
+              
+              print(f"  State: {job_state}, Health: {job_health}, Device: {job_device_type}")
+              
+              test_results = {}
+              
+              if job_state == "Finished" and job_health == "Complete":
+                  suites_data = fetch_job_suites(job_id)
+                  if not suites_data:
+                      return None
+                  
+                  suites = suites_data.get('results', [])
+                  
+                  for suite in suites:
+                      suite_name = suite.get('name')
+                      suite_id = suite.get('id')
+                      
+                      suite_tests = fetch_suite_tests(job_id, suite_id)
+                      if not suite_tests:
+                          continue
+                      
+                      tests = suite_tests.get('results', [])
+                      
+                      if suite_name != "lava":
+                          for test in tests:
+                              test_name = test.get('name')
+                              test_result = test.get('result')
+                              if test_name:
+                                  test_results[test_name] = {
+                                      'result': test_result,
+                                      'url': job_url
+                                  }
+                      else:
+                          test_results['boot'] = {
+                              'result': 'pass',
+                              'url': job_url
+                          }
+              
+              return {
+                  'device_type': job_device_type,
+                  'test_results': test_results,
+                  'job_id': job_id
+              }
+          
+          def generate_summary_table(job_results, summary_file):
+              if not job_results:
+                  print("No results to display")
+                  return
+              
+              all_test_names = set()
+              for job_file, job_info in job_results:
+                  all_test_names.update(job_info['test_results'].keys())
+              
+              test_names = sorted(all_test_names)
+              
+              lines = []
+              lines.append("# LAVA Test Job Results Summary")
+              lines.append("")
+              lines.append(f"**Total Jobs Processed:** {len(job_results)}")
+              lines.append("")
+              
+              # Header
+              header = "| Test |"
+              for job_file, job_info in job_results:
+                  device_type = job_info['device_type']
+                  header += f" {device_type} |"
+              lines.append(header)
+              
+              # Separator
+              separator = "| ---- |"
+              for _ in job_results:
+                  separator += " ---- |"
+              lines.append(separator)
+              
+              # Data rows
+              for test_name in test_names:
+                  row = f"| {test_name} |"
+                  
+                  for job_file, job_info in job_results:
+                      test_results = job_info['test_results']
+                      job_url = f"https://lava.infra.foundries.io/results/{job_info['job_id']}"
+                      
+                      if test_name in test_results:
+                          result = test_results[test_name].get('result', '')
+                          
+                          if result == 'pass':
+                              checkmark = ":white_check_mark:"
+                          elif result == 'fail':
+                              checkmark = ":x:"
+                          elif result == 'skip':
+                              checkmark = ":warning:"
+                          else:
+                              checkmark = ":no_entry_sign:"
+                          
+                          row += f" {checkmark} |"
+                      else:
+                          row += f" :no_entry_sign: |"
+                  
+                  lines.append(row)
+              
+              # Print to console
+              for line in lines:
+                  print(line)
+              
+              # Write to file
+              with open(summary_file, 'w') as f:
+                  for line in lines:
+                      f.write(line + '\n')
+              
+              print(f"\nSummary written to: {summary_file}")
+          
+          # Main execution
+          workspace = os.environ.get("GITHUB_WORKSPACE", ".")
+          prefix = os.environ.get("PREFIX", "test-job")
+          summary_file = os.environ.get("SUMMARY_FILE", "step-summary.txt")
+          
+          print(f"Workspace: {workspace}")
+          print(f"Looking for files matching: {prefix}*.json")
+          print("="*80)
+          
+          # Find test job files
+          test_job_files = []
+          for root, dirs, files in os.walk(workspace):
+              for file in files:
+                  if file.startswith(prefix) and file.endswith('.json'):
+                      test_job_files.append(os.path.join(root, file))
+          
+          if not test_job_files:
+              print(f"No test job files found")
+              sys.exit(1)
+          
+          print(f"Found {len(test_job_files)} test job file(s)\n")
+          
+          # Process jobs
+          job_results = []
+          for test_job_file in test_job_files:
+              result = process_test_job(test_job_file)
+              if result:
+                  job_results.append((test_job_file, result))
+              print()
+          
+          # Generate summary
+          generate_summary_table(job_results, summary_file)
+          EOF
+          
+          {
+            echo "### All jobs summary"
+            echo ""
+            echo "| Job ID | Device | State | Health |"
+            echo "| ---- | ---- | ---- | ---- |"
+          } >> "$SUMMARY_FILE"
+
+          # Find files and append to summary (safe quoting)
+          for TESTJOB in $(find "$GITHUB_WORKSPACE" -name "${PREFIX}*.json"); do
+              JOB_ID=$(jq -r ".id" "$TESTJOB")
+              JOB_URL="https://lava.infra.foundries.io/results/$JOB_ID"
+              JOB_DETAILS=$(curl -s "https://lava.infra.foundries.io/api/v0.2/jobs/$JOB_ID/")
+              JOB_HEALTH=$(echo "$JOB_DETAILS" | jq -r ".health")
+              JOB_STATE=$(echo "$JOB_DETAILS" | jq -r ".state")
+              JOB_DEVICE_TYPE=$(echo "$JOB_DETAILS" | jq -r ".requested_device_type")
+              echo "| $JOB_ID | $JOB_DEVICE_TYPE | $JOB_STATE | $JOB_HEALTH |" >> "$SUMMARY_FILE"
+          done
+
+      - name: Upload summary
+        id: upload-summary
+        uses: actions/upload-artifact@v6
+        with:
+          path: ${{ inputs.summary_file_name }}
+          name: ${{ inputs.summary_file_name }}

--- a/.github/workflows/post_merge_build.yml
+++ b/.github/workflows/post_merge_build.yml
@@ -32,10 +32,49 @@ jobs:
       build_command: ${{ needs.load_parameters.outputs.sdk_build_command }}
       build_type: sdk_build
 
+  filter_test_matrix:
+    needs: load_parameters
+    runs-on: ubuntu-latest
+    outputs:
+      test_matrix: ${{ steps.filter.outputs.test_matrix }}
+    steps:
+      - id: filter
+        shell: bash
+        run: |
+            MATRIX='${{ needs.load_parameters.outputs.build_matrix }}'
+
+            echo "RAW build_matrix:"
+            echo "$MATRIX"
+
+            echo "Validating JSON..."
+            echo "$MATRIX" | jq . >/dev/null
+
+            # Supports:
+            # 1) object keyed by name: { "name": {testing_enabled:true}, ... }
+            # 2) array of entries: [ {Testing_enabled:true,...}, ... ]  (will convert to include list)
+            FILTERED=$(
+              echo "$MATRIX" | jq -c '
+                if type == "object" then
+                  to_entries
+                  | map(select(.value.testing_enabled == true))
+                  | from_entries
+                elif type == "array" then
+                  map(select(.testing_enabled == true))  # <-- Just return the array
+                else
+                  error("Unsupported build_matrix JSON type: " + (type|tostring))
+                end
+              '
+            )
+
+            echo "Filtered matrix (pretty):"
+            echo "$FILTERED" | jq .
+
+            echo "test_matrix=$FILTERED" >> "$GITHUB_OUTPUT"
+
   tests:
-    needs: [load_parameters, flat_build]
+    needs: [load_parameters, flat_build,filter_test_matrix]
     if: ${{ always() && needs.flat_build.result != 'skipped' }}
     uses: ./.github/workflows/test.yml
     secrets: inherit
     with:
-      build_matrix: ${{ needs.load_parameters.outputs.build_matrix }}
+      build_matrix: ${{ needs.filter_test_matrix.outputs.test_matrix }}

--- a/.github/workflows/pre_merge_build.yml
+++ b/.github/workflows/pre_merge_build.yml
@@ -23,10 +23,49 @@ jobs:
       build_command: ${{ needs.load_parameters.outputs.flat_build }}
       build_type: flat_build
 
+  filter_test_matrix:
+    needs: load_parameters
+    runs-on: ubuntu-latest
+    outputs:
+      test_matrix: ${{ steps.filter.outputs.test_matrix }}
+    steps:
+      - id: filter
+        shell: bash
+        run: |
+            MATRIX='${{ needs.load_parameters.outputs.build_matrix }}'
+
+            echo "RAW build_matrix:"
+            echo "$MATRIX"
+
+            echo "Validating JSON..."
+            echo "$MATRIX" | jq . >/dev/null
+
+            # Supports:
+            # 1) object keyed by name: { "name": {testing_enabled:true}, ... }
+            # 2) array of entries: [ {Testing_enabled:true,...}, ... ]  (will convert to include list)
+            FILTERED=$(
+              echo "$MATRIX" | jq -c '
+                if type == "object" then
+                  to_entries
+                  | map(select(.value.testing_enabled == true))
+                  | from_entries
+                elif type == "array" then
+                  map(select(.testing_enabled == true))  # <-- Just return the array
+                else
+                  error("Unsupported build_matrix JSON type: " + (type|tostring))
+                end
+              '
+            )
+
+            echo "Filtered matrix (pretty):"
+            echo "$FILTERED" | jq .
+
+            echo "test_matrix=$FILTERED" >> "$GITHUB_OUTPUT"
+
   tests:
-    needs: [load_parameters, flat_build]
+    needs: [load_parameters, flat_build,filter_test_matrix]
     if: ${{ (success() || failure()) && !contains(needs.flat_build.result, 'skipped') }}
     uses: ./.github/workflows/test.yml
     secrets: inherit
     with:
-      build_matrix: ${{ needs.load_parameters.outputs.build_matrix }}
+      build_matrix: ${{ needs.filter_test_matrix.outputs.test_matrix }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,15 +9,54 @@ on:
         required: true
         type: string
         description: Build matrix for the test job
+      
+      # === Optional knobs for lava-test-plans ===
+      distro_name:
+        description: Default distro for lava-test-plans if not provided in matrix
+        required: false
+        type: string
+        default: qcom-distro
+      kernel:
+        description: Extra path suffix for kernel (e.g., -6.18). Default empty.
+        required: false
+        type: string
+        default: ""
+      testplan:
+        description: Test plan name to use in job generation (lava-test-plans)
+        required: false
+        type: string
+        default: pre-merge
+      prefix:
+        description: Prefix for the compressed artifact with generated jobs
+        required: false
+        type: string
+        default: testjobs
+      
+      # === LAVA server configuration ===
+      lava_url:
+        description: LAVA server URL
+        required: false
+        type: string
+        default: lava.infra.foundries.io
+      wait_for_job:
+        description: Wait for LAVA job to complete
+        required: false
+        type: boolean
+        default: true
+      fail_on_test_failure:
+        description: Fail workflow if LAVA test fails
+        required: false
+        type: boolean
+        default: false
 
 jobs:
-  test:
+ submit_lava:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         build_matrix: ${{ fromJson(inputs.build_matrix) }}
-
+    
     steps:
       - name: Sync Codebase
         id: sync
@@ -35,74 +74,81 @@ jobs:
           MACHINE: ${{ matrix.build_matrix.machine_name }}
           ARTIFACT_KEY: ${{ matrix.build_matrix.kas_file }}
 
-      - name: Print trigger
+      - name: Print trigger info
+        id: print_trigger
         run: |
           echo "Triggered by ${{ github.event_name }}"
           echo "Build URL: ${{ steps.process_urls.outputs.flat_build_url }}"
           echo "Build file name: ${{ steps.process_urls.outputs.filename }}"
+          echo "Image: ${{ matrix.build_matrix.image_name }}"
+          echo "Machine: ${{ matrix.build_matrix.machine_name }}"
+          KAS_FILE="${{ matrix.build_matrix.kas_file }}"
+          KAS_FILE="${KAS_FILE##*/}"
+          IMAGE_NAME="${KAS_FILE%.*}"
+          echo "image_name=$IMAGE_NAME" >> "$GITHUB_OUTPUT" 
+      
+      - name: Submit LAVA test job
+        id: lava_submit
+        uses: Audioreach/meta-audioreach/.github/actions/lava-test-plans@master
+        with:
+          image_name: ${{ steps.print_trigger.outputs.image_name}}
+          machine_name: ${{ matrix.build_matrix.machine_name }}
+          build_url: ${{ steps.process_urls.outputs.flat_build_url }}
+          distro_name: ${{ inputs.distro_name }}
+          kernel: ${{ inputs.kernel }}
+          testplan: ${{ inputs.testplan }}
+          prefix: ${{ inputs.prefix }}
+          lava_token: ${{ secrets.LAVATOKEN }}
+          lava_url: ${{ inputs.lava_url }}
+          wait_for_job: ${{ inputs.wait_for_job }}
+          fail_action_on_failure: ${{ inputs.fail_on_test_failure }}
+          run_id: ${{ github.run_id }}
+          run_attempt: ${{ github.run_attempt }}
+  
+ publish-test-summary:
+    name: "Publish Tests Summary"
+    needs: [submit_lava]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+    outputs:
+      summary_id: ${{ steps.generate-summary.outputs.artifact_id }}
 
-      - name: Modify test configurations
-        id: listjobs
-        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate Summary
+        id: generate-summary
+        uses: Audioreach/meta-audioreach/.github/actions/test-job-summary@master
+        with:
+          build_id: ${{ github.run_id }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          summary_file_name: test_job_summary
+      
+      # Download ALL matching summary artifacts from parallel jobs and put into one folder.
+      - name: Download Summaries
+        uses: actions/download-artifact@v6
+        with:
+          pattern: test_job_summary*          # match all parallel summaries
+          merge-multiple: true                # place all matched artifact contents into a single folder
+          path: summaries
+
+      - name: Publish Test Job Details
         run: |
-          kas_file="${{ matrix.build_matrix.kas_file }}"
-          DIR_NAME="$(basename "$kas_file" .yml)"
-          target_file="ci/lava/${DIR_NAME}/boot.yaml"
-
-          if [ ! -f "$target_file" ]; then
-            echo "Target file $target_file does not exist."
-            echo "target_file=" >> "$GITHUB_OUTPUT"
+          shopt -s nullglob
+          files=(summaries/test_job_summary*)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo ":warning: No test job summaries were found to publish." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
-          TARGET=${target_file}
-          FIND_PATH="${TARGET#*/}"
-          DEVICE_TYPE_PATH="${FIND_PATH%/*}"
-          DEVICE_TYPE="${DEVICE_TYPE_PATH#*/}"
-
-          # ---- If device type has kernel suffix (6.18), normalize to base device type ----
-          if [ "$DEVICE_TYPE" = "rb3gen2-core-kit-6.18" ]; then
-            DEVICE_TYPE="rb3gen2-core-kit"
-          fi
-
-          GITHUB_SHA="${{ github.sha }}"
-          GITHUB_RUN_ID="${{ github.run_id }}"
-          BUILD_FILE_NAME="${{ steps.process_urls.outputs.filename }}"
-          BUILD_DOWNLOAD_URL="${{ steps.process_urls.outputs.flat_build_url }}"
-
-          sed -i "s|{{DEVICE_TYPE}}|${DEVICE_TYPE}|g" "${target_file}"
-          sed -i "s|{{GITHUB_SHA}}|${GITHUB_SHA}|g" "${target_file}"
-
-          ESCAPED_URL=$(echo "$BUILD_DOWNLOAD_URL" | sed 's/[&/?=]/\\&/g')
-          sed -i "s|{{BUILD_DOWNLOAD_URL}}|$ESCAPED_URL|g" "${target_file}"
-
-          sed -i "s|{{BUILD_FILE_NAME}}|${BUILD_FILE_NAME}|g" "${target_file}"
-          sed -i "s|{{GITHUB_RUN_ID}}|${GITHUB_RUN_ID}|g" "${target_file}"
-
-          cat "${target_file}"
-
-          echo "target_file=${target_file}" >> "$GITHUB_OUTPUT"
-      
-      - name: Test ${{ matrix.build_matrix.machine_name }}
-        if: ${{ steps.listjobs.outputs.target_file != '' }}
-        id: submit_job
-        timeout-minutes: 20
-        uses: foundriesio/lava-action@v6
-        with:
-          lava_token: ${{ secrets.LAVATOKEN }}
-          lava_url: 'lava.infra.foundries.io'
-          job_definition: ${{ steps.listjobs.outputs.target_file }}
-          wait_for_job: true
-          fail_action_on_failure: true
-          save_result_as_artifact: true
-          save_job_details: true
-
-      - name: Update Summary
-        if: ${{ always() }}
-        run: |
-          echo "## Test Job Summary" >> "$GITHUB_STEP_SUMMARY"
-          if [ "${{ steps.submit_job.outcome }}" = "success" ]; then
-            echo ":heavy_check_mark: Test job for ${{ matrix.build_matrix.machine_name }} completed successfully." >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo ":x: Test job for ${{ matrix.build_matrix.machine_name }} failed." >> "$GITHUB_STEP_SUMMARY"
-          fi
+          echo "## LAVA Test Job Summaries" >> "$GITHUB_STEP_SUMMARY"
+          for f in "${files[@]}"; do
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "### $(basename "$f")" >> "$GITHUB_STEP_SUMMARY"
+            cat "$f" >> "$GITHUB_STEP_SUMMARY"
+          done

--- a/ci/MACHINES.json
+++ b/ci/MACHINES.json
@@ -2,21 +2,25 @@
   "8275-evk": {
     "file_name": "meta-audioreach/ci/iq-8275-evk.yml",
     "machine_name": "8275-evk",
-    "image_name":"iq-8275-evk"
+    "image_name":"iq-8275-evk",
+    "testing_enabled": false
   },
   "9075-evk": {
     "file_name": "meta-audioreach/ci/iq-9075-evk.yml",
     "machine_name": "9075-evk",
-    "image_name":"iq-9075-evk"
+    "image_name":"iq-9075-evk",
+    "testing_enabled": false
   },
   "rb3gen2-core-kit": {
     "file_name": "meta-audioreach/ci/rb3gen2-core-kit.yml",
     "machine_name": "rb3gen2-core-kit",
-    "image_name":"rb3gen2-core-kit"
+    "image_name":"rb3gen2-core-kit",
+    "testing_enabled": true
   },
   "rb3gen2-core-kit-6.18": {
     "file_name": "meta-audioreach/ci/rb3gen2-core-kit-6.18.yml",
     "machine_name": "rb3gen2-core-kit",
-    "image_name":"rb3gen2-core-kit"
+    "image_name":"rb3gen2-core-kit",
+    "testing_enabled": true
   }
 }

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -33,6 +33,13 @@ repos:
     branch: master
     url: https://github.com/uptane/meta-updater
 
+  meta-security:
+    url: https://git.yoctoproject.org/meta-security
+    branch: master
+    layers:
+      .:
+      meta-tpm:
+
 local_conf_header:
   virtualization:
     SKIP_META_VIRT_SANITY_CHECK = "1"


### PR DESCRIPTION
Add support to plug and play targets and enable publishing of test
summaries. Integrate the meta-security layer into qcom-distro.yml
as referenced in [1].

[1] https://github.com/qualcomm-linux/meta-qcom/pull/1504