### PR TITLE
base.yml: fix IMAGE_INSTALL append spacing

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -44,7 +44,7 @@ local_conf_header:
     INHERIT += "buildstats-summary"
     INHERIT += "buildhistory"
     INHERIT += "rm_work"
-    IMAGE_INSTALL:append = "packagegroup-audioreach"
+    IMAGE_INSTALL:append = " packagegroup-audioreach"
   cmdline: |
     KERNEL_CMDLINE_EXTRA:append = " qcom_scm.download_mode=1"
   qcomflash: |


### PR DESCRIPTION
Add leading whitespace to IMAGE_INSTALL:append to prevent package name concatenation, which caused DNF "Unable to find a match" during rootfs.

Error: Unable to find a match: gst-plugins-imsdk-oss-metapackagegroup-audioreach