### PR TITLE
Enforce mandatory testplan and add post-merge testplan support

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -26,7 +26,7 @@ inputs:
     default: ''
   testplan:
     description: 'Test plan name to use in job generation'
-    required: false
+    required: true
     default: 'pre-merge'
   prefix:
     description: 'Prefix for the compressed artifact with generated jobs'
@@ -121,6 +121,7 @@ runs:
         case "$TESTPLAN_INPUT" in
           boot)  TESTPLAN_DIR="boot" ;;
           pre-merge|pre-merge-basic|pre-merge-bt) TESTPLAN_DIR="pre-merge" ;;
+          post-merge|post-merge-*|post-merge*) TESTPLAN_DIR="post-merge" ;;
           *)     TESTPLAN_DIR="$TESTPLAN_INPUT" ;;
         esac
 

--- a/.github/workflows/post_merge_build.yml
+++ b/.github/workflows/post_merge_build.yml
@@ -3,6 +3,12 @@ name: post_merge_build
 
 on:
   workflow_dispatch:
+    inputs:
+      testplan:
+        description: 'Test plan name to use in job generation (lava-test-plans)'
+        required: false
+        type: string
+        default: 'post-merge'
   push:
     branches:
       - master
@@ -78,3 +84,4 @@ jobs:
     secrets: inherit
     with:
       build_matrix: ${{ needs.filter_test_matrix.outputs.test_matrix }}
+      testplan: ${{ inputs.testplan != '' && inputs.testplan || 'post-merge' }}

--- a/.github/workflows/pre_merge_build.yml
+++ b/.github/workflows/pre_merge_build.yml
@@ -3,6 +3,12 @@ name: pre_merge_build
 run-name: Pre Merge Build ${{ github.event.pull_request.number != '' && github.event.pull_request.number || '' }}
 on:
   workflow_dispatch:
+    inputs:
+      testplan:
+        description: 'Test plan name to use in job generation (lava-test-plans)'
+        required: false
+        type: string
+        default: 'pre-merge'
   pull_request_target: # requiring access to base repo
     types: [opened, synchronize, reopened]
     branches:
@@ -69,3 +75,4 @@ jobs:
     secrets: inherit
     with:
       build_matrix: ${{ needs.filter_test_matrix.outputs.test_matrix }}
+      testplan: ${{ inputs.testplan != '' && inputs.testplan || 'pre-merge' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,9 @@ on:
         default: ""
       testplan:
         description: Test plan name to use in job generation (lava-test-plans)
-        required: false
+        required: true
         type: string
-        default: pre-merge
+        default: 'pre-merge'
       prefix:
         description: Prefix for the compressed artifact with generated jobs
         required: false


### PR DESCRIPTION
Make testplan input mandatory across all workflows.
Add post-merge testplan support and extend action mappings.