### PR TITLE
recipes-kernel: Add VENDOR_QCOM Makefile flag

### DIFF
--- a/recipes-kernel/audioreach-kernel/audioreach-kernel_git.bb
+++ b/recipes-kernel/audioreach-kernel/audioreach-kernel_git.bb
@@ -20,6 +20,8 @@ MAKE_TARGETS = "modules"
 
 MODULES_MODULE_SYMVERS_LOCATION = "audioreach-driver"
 
+EXTRA_OEMAKE:append:qcom = " VENDOR_QCOM=1"
+
 do_install:append() {
     install -d ${D}${sysconfdir}/udev/rules.d
     install -m 0644 ${UNPACKDIR}/audioreach.rules ${D}${sysconfdir}/udev/rules.d/


### PR DESCRIPTION
Add VENDOR_QCOM flag, which will be passed to the audioreach-driver Makefile to enable/disable the RPMsg packet driver.

audioreach-driver reference: https://github.com/AudioReach/audioreach-kernel/blob/master/audioreach-driver/Makefile#L5