### PR TITLE
Update LAYERSERIES_COMPAT to wrynose

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -5,4 +5,4 @@ BBFILE_PRIORITY_meta-audioreach = "6"
 BBFILE_PATTERN_meta-audioreach := "^${LAYERDIR}/"
 
 LAYERDEPENDS_meta-audioreach = "multimedia-layer"
-LAYERSERIES_COMPAT_meta-audioreach = "whinlatter"
+LAYERSERIES_COMPAT_meta-audioreach = "wrynose"


### PR DESCRIPTION
OE-core has switched to using wrynose release name. Adjust LAYERSERIES_COMPAT accordingly.