### PR TITLE
audioreach-graphservices: srcrev bump 7a76df6...9e83632

### DIFF
--- a/recipes/audioreach-graphservices/audioreach-graphservices_git.bb
+++ b/recipes/audioreach-graphservices/audioreach-graphservices_git.bb
@@ -3,7 +3,7 @@ SUMMARY = "AudioReach Graph Service"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ef516c5438f1b599326a5e207572f477"
 
-SRCREV = "7a76df677606833ccb7521a1487ae1129a9c3f04"
+SRCREV = "9e83632e4e8a6f775fda8be14358d54d422b5cb0"
 PV = "0.0+git"
 SRC_URI = "git://git@github.com/Audioreach/audioreach-graphservices.git;protocol=https;branch=master"
 


### PR DESCRIPTION
Commits included in this version bump are below:

6ef6120 Makefile: SPF: Add ASR usecase API header to API paths
b4debf2 osal/shmem: clean up and refine APSS‑specific sys_id validation logic
0722e9d SPF: Add Soft Pause Module API Header
9cfd577 args: spf: add headers to support ASPS based ASR usecase
ea368f9 osal/shmem: add support to differentiate ARM vs DSP data processing
bf9600e spf: api: Update haptics api changes for SH 3.1
6299c76 CI: Remove CFLAGS override and update configure header path
3e71049 Enable ABI checks
1d2017a Enable Kaanapali and Pakala target compilation
4f349cd gsl: remove definition from source file
75a722c args: cshm: client shared memory support
ee33025 Grant workflow permissions to enable PR checks in pre-merge build
c25975e Enable RPI target in pre-merge workflows
a8aa88e Adds pre_build script to download & run SDK script
ebc684f CI: Add job to filter test-ready entries from build_matrix for LAVA
cd0e820 CI: Update pre-merge build flows