### PR TITLE
ci/qcom-distro: fix meta-security wic

### DIFF
--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -36,6 +36,10 @@ repos:
   meta-security:
     url: https://git.yoctoproject.org/meta-security
     branch: master
+    patches:
+      plain:
+        repo: meta-qcom
+        path: patches/0001-wic-wic-need-to-be-moved-to-files-wic-within-the-lay.patch
     layers:
       .:
       meta-tpm:


### PR DESCRIPTION
This is to unblock ci and will be reverted as soon as they are integrated into the upstream layer.