### PR TITLE
audioreach-kernel: srcrev bump bcf17af..6d3d0f

### DIFF
--- a/recipes-kernel/audioreach-kernel/audioreach-kernel-headers_git.bb
+++ b/recipes-kernel/audioreach-kernel/audioreach-kernel-headers_git.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/AudioReach/audioreach-kernel"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d683615f65309f6c050cbd1bb2b3c575"
 
-SRCREV = "2d26f557e1ccc3e5e9bea0b843671805b3fe8d5e"
+SRCREV = "6d3d0f0fe054d229b736bd56669f75779a218732"
 PV = "0.0+git"
 SRC_URI = "git://github.com/AudioReach/audioreach-kernel.git;protocol=https;branch=master"
 

--- a/recipes-kernel/audioreach-kernel/audioreach-kernel_git.bb
+++ b/recipes-kernel/audioreach-kernel/audioreach-kernel_git.bb
@@ -10,7 +10,7 @@ SRC_URI = "git://github.com/AudioReach/audioreach-kernel.git;protocol=https;bran
            file://asoc-blacklist.conf \
            file://v1-0001-audioreach-driver-audioreach-common-Fix-WSA-Mute-.patch \
     "
-SRCREV = "bcf17af355896c61bd176e7eecfac12ee774f4c0"
+SRCREV = "6d3d0f0fe054d229b736bd56669f75779a218732"
 
 PV = "0.0+git"
 


### PR DESCRIPTION
Commits included in this version bump are below:
audioreach-kernel: Add X1E80100 sound card support
audioreach-driver: Audio pkt driver code clean up
audioreach-driver: Remove header dependencies and fix compilation warnings
audioreach-driver: add the missing LPASS MCLK clock IDs