### PR TITLE
Enable compilation for kaanapali-mtp and sm8750-mtp targets

### DIFF
--- a/ci/MACHINES.json
+++ b/ci/MACHINES.json
@@ -48,5 +48,25 @@
       "flat_build": "bitbake core-image-sato",
       "sdk_build": "bitbake core-image-sato && bitbake core-image-sato -c populate_sdk"
     }
+  },
+  "kaanapali-mtp": {
+    "file_name": "meta-audioreach/ci/kaanapali-mtp.yml",
+    "machine_name": "kaanapali-mtp",
+    "image_name": "kaanapali-mtp",
+    "testing_enabled": false,
+    "build_commands": {
+      "flat_build": "bitbake qcom-multimedia-image",
+      "sdk_build": "bitbake qcom-multimedia-image && bitbake qcom-multimedia-image -c populate_sdk"
+    }
+  },
+  "sm8750-mtp": {
+    "file_name": "meta-audioreach/ci/sm8750-mtp.yml",
+    "machine_name": "sm8750-mtp",
+    "image_name": "sm8750-mtp",
+    "testing_enabled": false,
+    "build_commands": {
+      "flat_build": "bitbake qcom-multimedia-image",
+      "sdk_build": "bitbake qcom-multimedia-image && bitbake qcom-multimedia-image -c populate_sdk"
+    }
   }
 }

--- a/ci/kaanapali-mtp.yml
+++ b/ci/kaanapali-mtp.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+  - ci/base.yml
+  - ci/qcom-distro.yml
+
+machine: kaanapali-mtp

--- a/ci/sm8750-mtp.yml
+++ b/ci/sm8750-mtp.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+  - ci/base.yml
+  - ci/qcom-distro.yml
+
+machine: sm8750-mtp


### PR DESCRIPTION
Add kaanapali-mtp and sm8750-mtp machines to
ci/MACHINES.json to allow CI compilation.

Introduce KAS configuration files for both targets using base and Qualcomm distro includes.

Configure qcom-multimedia-image builds and SDK
generation while keeping runtime testing disabled.