### PR TITLE
audioreach-kernel: srcrev bump 6d3d0f0..bf478f8

### DIFF
--- a/recipes-kernel/audioreach-kernel/audioreach-kernel-headers_git.bb
+++ b/recipes-kernel/audioreach-kernel/audioreach-kernel-headers_git.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/AudioReach/audioreach-kernel"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d683615f65309f6c050cbd1bb2b3c575"
 
-SRCREV = "6d3d0f0fe054d229b736bd56669f75779a218732"
+SRCREV = "bf478f88d42068a9bd90cbd8162171acce8114d6"
 PV = "0.0+git"
 SRC_URI = "git://github.com/AudioReach/audioreach-kernel.git;protocol=https;branch=master"
 

--- a/recipes-kernel/audioreach-kernel/audioreach-kernel/asoc-blacklist.conf
+++ b/recipes-kernel/audioreach-kernel/audioreach-kernel/asoc-blacklist.conf
@@ -5,3 +5,4 @@ blacklist q6prm-clocks
 blacklist q6prm
 blacklist snd-q6apm
 blacklist snd-soc-sc8280xp
+blacklist snd-soc-x1e80100

--- a/recipes-kernel/audioreach-kernel/audioreach-kernel_git.bb
+++ b/recipes-kernel/audioreach-kernel/audioreach-kernel_git.bb
@@ -10,7 +10,7 @@ SRC_URI = "git://github.com/AudioReach/audioreach-kernel.git;protocol=https;bran
            file://asoc-blacklist.conf \
            file://v1-0001-audioreach-driver-audioreach-common-Fix-WSA-Mute-.patch \
     "
-SRCREV = "6d3d0f0fe054d229b736bd56669f75779a218732"
+SRCREV = "bf478f88d42068a9bd90cbd8162171acce8114d6"
 
 PV = "0.0+git"
 


### PR DESCRIPTION
Commits included in this version bump are below:
audioreach-driver: q6apm_audio_pkt: Fix crash issue after command timeout during SSR
audioreach-driver: audioreach-common: Add Glymur sound card support

And also blacklist the Glymur ASoC machine driver in audioreach since the compatible is
now handled by the audioreach driver.