### PR TITLE
Revert "ci/qcom-distro: fix meta-security wic"

### DIFF
--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -36,10 +36,6 @@ repos:
   meta-security:
     url: https://git.yoctoproject.org/meta-security
     branch: master
-    patches:
-      plain:
-        repo: meta-qcom
-        path: patches/0001-wic-wic-need-to-be-moved-to-files-wic-within-the-lay.patch
     layers:
       .:
       meta-tpm:


### PR DESCRIPTION
This reverts commit 266e32258e87c5f2ca4b2271dbe83ae650f5d870.

Fix lands upstream in meta-security.