### PR TITLE
audioreach-pal: switch recipes to master branch

### DIFF
--- a/recipes/audioreach-pal/audioreach-pal-headers_git.bb
+++ b/recipes/audioreach-pal/audioreach-pal-headers_git.bb
@@ -6,8 +6,8 @@ LICENSE = "BSD-3-Clause-Clear"
 LIC_FILES_CHKSUM = "file://${UNPACKDIR}/${PN}-${PV}/LICENSE;md5=51110a366f598bc0b8f8e59141a18efb"
 
 SRCPROJECT = "git://github.com/AudioReach/audioreach-pal.git"
-SRCBRANCH  = "qclinux1.0"
-SRCREV     = "db8e49786864da61fd55d5df1326094c63191df8"
+SRCBRANCH  = "master"
+SRCREV     = "4a13cc426171047b00de1ad8f76d058cba89c95a"
 PV = "0.0+git"
 
 SRC_URI = "${SRCPROJECT};protocol=https;branch=${SRCBRANCH};"

--- a/recipes/audioreach-pal/audioreach-pal_git.bb
+++ b/recipes/audioreach-pal/audioreach-pal_git.bb
@@ -5,9 +5,9 @@ LICENSE = "BSD-3-Clause-Clear"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=51110a366f598bc0b8f8e59141a18efb"
 
 SRCPROJECT = "git://github.com/AudioReach/audioreach-pal.git"
-SRCBRANCH  = "qclinux1.0"
+SRCBRANCH  = "master"
 
-SRCREV = "db8e49786864da61fd55d5df1326094c63191df8"
+SRCREV = "4a13cc426171047b00de1ad8f76d058cba89c95a"
 PV = "0.0+git"
 SRC_URI  = "${SRCPROJECT};protocol=https;branch=${SRCBRANCH}"
 


### PR DESCRIPTION
Update audioreach-pal and audioreach-pal-headers recipes to track the upstream master branch instead of qclinux1.0.