### PR TITLE
srcrev bump of audioreach-graphmgr, audioreach-graphservices, audioreach-conf

### DIFF
--- a/recipes/audioreach-conf/audioreach-conf_git.bb
+++ b/recipes/audioreach-conf/audioreach-conf_git.bb
@@ -1,10 +1,10 @@
 DESCRIPTION = "AudioReach configurations"
 HOMEPAGE = "https://github.com/Audioreach/audioreach-conf"
 
-LICENSE = "BSD-3-Clause-Clear"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=51110a366f598bc0b8f8e59141a18efb"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=849c526521c1203a789a87389d328892"
 
-SRCREV = "cb9e696b1c8c6d93090bb653b09a7d8a7aa2f80b"
+SRCREV = "e4de9ba743a43fb4430db083ce98fb8ccd37d2c6"
 PV = "1.0+git${SRCPV}"
 
 SRC_URI = "git://github.com/Audioreach/audioreach-conf.git;protocol=https;branch=master"

--- a/recipes/audioreach-graphmgr/audioreach-graphmgr_git.bb
+++ b/recipes/audioreach-graphmgr/audioreach-graphmgr_git.bb
@@ -3,7 +3,7 @@ SUMMARY = "AudioReach Graph Manager"
 LICENSE = "BSD-3-Clause-Clear"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=51110a366f598bc0b8f8e59141a18efb"
 
-SRCREV = "ee5a7d24654289caa68532342f6439eea689f14c"
+SRCREV = "b5587a73c25085268aad89839fea04906063385d"
 PV = "0.0+git"
 SRC_URI = "git://git@github.com/Audioreach/audioreach-graphmgr.git;protocol=https;branch=master"
 SRC_URI     += "file://agm_server.service"

--- a/recipes/audioreach-graphservices/audioreach-graphservices_git.bb
+++ b/recipes/audioreach-graphservices/audioreach-graphservices_git.bb
@@ -3,7 +3,7 @@ SUMMARY = "AudioReach Graph Service"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ef516c5438f1b599326a5e207572f477"
 
-SRCREV = "9e83632e4e8a6f775fda8be14358d54d422b5cb0"
+SRCREV = "65320f2c38b2ee675ae674764b3932820551fb55"
 PV = "0.0+git"
 SRC_URI = "git://git@github.com/Audioreach/audioreach-graphservices.git;protocol=https;branch=master"
 


### PR DESCRIPTION
audioreach-graphmgr: srcrev bump ee5a7d2...b5587a7

Commits included in this version bump are below:

2cadb1e agm: avoid using ATOMIC_VAR_INIT for atomic_bool init
af2ebf6 DBus:agm_server: fix memcpy against buf_size overflow 
2fb4f2b agm:ats: add property control and fix init thread races
a7f1533 agm: service: fix typecasting issues for GCC 14.2 
9521ef0 plugins: test: Correct null check for compress
4f2afc1 plugins: enable AGM syslog flag and update installation folder
3a1e8e0 plugins: add support for ALSA plugin
dab6f2f alsalib: fix session_mode type mismatch in agm_io_plugin 
ca6c876 agm: implement aidl apis in dbus and SW binders 
a4ea858 Include gsl_intf.h to resolve missing API references in agm.c 
a017635 snd_parser: Makefile.am: Add missing CARD_DEF_FILE_NATIVE 
macro 
d16d4aa plugins: tinyalsa: Register new mixer control for CSHM 
b885b29 agm: Extend AGM interface for CSHM
1679734 agm: ipc: Add support for client shared memory feature 
03c4de2 agm: add non-ipc plugin libs & support dynamic card-id xml
parsing
e072bc1 Enable Kaanapali and Pakala target compilation 
4ce3fd5 Switch pre-merge workflow to pull_request_target trigger
b067933 Harden PR workflow triggers and enable ABI checks 
73bd8d3 CI: Remove CFLAGS override and externalize RPI build args 
f68b135 Add pre_build script for SDK setup
2ae0322 CI: Add ras_build.sh to the CI directory
6cab554 Enable raspberrypi target in pre-merge workflows 
ada9eb2 tinyalsa/test: clean up agmmixer API and fix issues 
b1407eb CI: Add job to filter test-ready entries from build_matrix for
LAVA
0aab668 CI: Update pre-merge build flows

audioreach-graphservices: srcrev bump 9e83632...2cf853c

Commits included in this version bump are below:

002a53b ar_osal: add USE_LIBDIAG_HEADERS flag and drop liblog 
dependency
08062cd Remove unused comdef.h include from audtp.h
897ba26 spf: Add necessary headers support to build
875a619 args: Add bounds checking for persist_cal_idx to prevent
out-of-bounds
64dc405 args: Fix NULL dereference caused by invalid old_node pointer
fae28cb args: Fix double free of global persist calibration data
ea87e90 args: gpr: Remove redundant NULL check
bc23469 library versioning in build configuration


audioreach-conf: srcrev bump cb9e696...e4de9ba

Update LICENSE and LIC_FILES_CHKSUM to match audioreach-conf licence.
 
Commits included in this version bump are below:
3b13bd3 acdbdata : kvh2xml : add tag to set dynamic transition mode on
FNN_NS module
80a51cb Update license marking
8883300 Update copyright headers to reflect Qualcomm Technologies, Inc.
02c19df kvh2xml: Add streamPP vad SG value
c10602c acdbdata: Add macros for 4 channels
74aabec CI: Disable armor checkers in qcom preflight workflow
0d01a80 Update library version references in build files