### PR TITLE
audioreach-graphservices: enable libdiag support for QACT on qcom targets

### DIFF
--- a/recipes/audioreach-graphservices/audioreach-graphservices_git.bb
+++ b/recipes/audioreach-graphservices/audioreach-graphservices_git.bb
@@ -8,10 +8,11 @@ PV = "0.0+git"
 SRC_URI = "git://git@github.com/Audioreach/audioreach-graphservices.git;protocol=https;branch=master"
 
 DEPENDS = "glib-2.0"
-DEPENDS:append:qcom = " audioreach-kernel-headers"
-EXTRA_OECONF += "--with-syslog --with-glib --without-cutils --with-dummy_diag"
+DEPENDS:append:qcom = " audioreach-kernel-headers libdiag"
+EXTRA_OECONF += "--with-syslog --with-glib --without-cutils"
 EXTRA_OECONF:append:qcom = " --with-qcom --with-audio_dma_support --without-ats_transport_tcp_ip \
                              --without-ats_data_logging --with-msm-audio-ion-disable \
+                             --without-dummy_diag --with-libdiag_headers \
 "
 
 SOLIBS = ".so*"
@@ -25,3 +26,4 @@ RRECOMMENDS:${PN} = " \
    kernel-module-audio-pkt \
    kernel-module-spf-core \
 "
+RDEPENDS:${PN}:append:qcom = " diag-router"


### PR DESCRIPTION
AudioReach graphservices requires libdiag support on Qualcomm targets
to enable QACT connection and diagnostics over USB. This functionality
relies on libdiag headers and the diag router at runtime.
Update the recipe to enable libdiag integration for qcom builds by
adding the required build and runtime dependencies, disabling the
dummy diagnostic implementation, and configuring graphservices to
use the real diagnostics path where applicable.