### PR TITLE
audioreach-conf: srcrev bump 59f8e83..cb9e696

### DIFF
--- a/recipes/audioreach-conf/audioreach-conf_git.bb
+++ b/recipes/audioreach-conf/audioreach-conf_git.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/Audioreach/audioreach-conf"
 LICENSE = "BSD-3-Clause-Clear"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=51110a366f598bc0b8f8e59141a18efb"
 
-SRCREV = "6a02c7c70fd2821cd79c415bd084fc0ed261a304"
+SRCREV = "4ff045ad5f527de70896ce77bdcdea5ad086dc16"
 PV = "1.0+git${SRCPV}"
 
 SRC_URI = "git://github.com/Audioreach/audioreach-conf.git;protocol=https;branch=master"

--- a/recipes/audioreach-conf/audioreach-conf_git.bb
+++ b/recipes/audioreach-conf/audioreach-conf_git.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/Audioreach/audioreach-conf"
 LICENSE = "BSD-3-Clause-Clear"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=51110a366f598bc0b8f8e59141a18efb"
 
-SRCREV = "51e9a2dbfbafea73a262671e2f13f1c013599ed1"
+SRCREV = "6a02c7c70fd2821cd79c415bd084fc0ed261a304"
 PV = "1.0+git${SRCPV}"
 
 SRC_URI = "git://github.com/Audioreach/audioreach-conf.git;protocol=https;branch=master"

--- a/recipes/audioreach-conf/audioreach-conf_git.bb
+++ b/recipes/audioreach-conf/audioreach-conf_git.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/Audioreach/audioreach-conf"
 LICENSE = "BSD-3-Clause-Clear"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=51110a366f598bc0b8f8e59141a18efb"
 
-SRCREV = "59f8e83b246f920321998106203e440772eda1e1"
+SRCREV = "1ea14ca2aff769e4311198a7693ac2d7f3828bff"
 PV = "1.0+git${SRCPV}"
 
 SRC_URI = "git://github.com/Audioreach/audioreach-conf.git;protocol=https;branch=master"

--- a/recipes/audioreach-conf/audioreach-conf_git.bb
+++ b/recipes/audioreach-conf/audioreach-conf_git.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/Audioreach/audioreach-conf"
 LICENSE = "BSD-3-Clause-Clear"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=51110a366f598bc0b8f8e59141a18efb"
 
-SRCREV = "1ea14ca2aff769e4311198a7693ac2d7f3828bff"
+SRCREV = "51e9a2dbfbafea73a262671e2f13f1c013599ed1"
 PV = "1.0+git${SRCPV}"
 
 SRC_URI = "git://github.com/Audioreach/audioreach-conf.git;protocol=https;branch=master"

--- a/recipes/audioreach-conf/audioreach-conf_git.bb
+++ b/recipes/audioreach-conf/audioreach-conf_git.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/Audioreach/audioreach-conf"
 LICENSE = "BSD-3-Clause-Clear"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=51110a366f598bc0b8f8e59141a18efb"
 
-SRCREV = "4ff045ad5f527de70896ce77bdcdea5ad086dc16"
+SRCREV = "cb9e696b1c8c6d93090bb653b09a7d8a7aa2f80b"
 PV = "1.0+git${SRCPV}"
 
 SRC_URI = "git://github.com/Audioreach/audioreach-conf.git;protocol=https;branch=master"


### PR DESCRIPTION
Commits included in this version bump are below:

CI: Update pre-merge build flows
CI: Add job to filter test-ready entries from build_matrix for LAVA
audioreach-conf: Add SM8750 audio configuration files
Add pre_build script for SDK setup
Grant workflow permissions to enable PR checks in pre-merge build
CI: Update build files to enable pre-merge compilation
Enable Kaanapali and Pakala target compilation
Enable RPI target in pre-merge workflows
audioreach-conf: remove unused AC_CONFIG_MACRO_DIR from configure files
acdbdata: clean up unused modules and use cases
qcm6490: add ACDB install path for QCM6490 IDP
audioreach-conf: Add GLYMUR audio configuration files
audioreach-conf: Add X1E80100 audio configuration files
audioreach-conf: Add MAHUA audio configuration files
audioreach-conf: Add Kaanapali audio configuration files
qcs615: remove SMECNS module for headset + SMECNS use case.
qcs615: Add ACDB data files for Talos EVK.
audioreach-conf: Lemans-EVK: change I2S data line to SD0
audioreach-conf: acdb: update directory structure for ACDB
audioreach-conf: docs: update README file
audioreach-conf: Monaco-EVK: change I2S data line to SD0
Use meta-qcom environment in build script
