### PR TITLE
Harden aws-s3 composite action input handling

### DIFF
--- a/.github/actions/aws-s3-exchanger/action.yml
+++ b/.github/actions/aws-s3-exchanger/action.yml
@@ -30,51 +30,56 @@ runs:
       id: sync-data
       shell: bash
       env:
+        INPUT_S3_BUCKET: ${{ inputs.s3_bucket }}
+        INPUT_LOCAL_FILE: ${{ inputs.local_file }}
+        INPUT_DOWNLOAD_FILE: ${{ inputs.download_file }}
+        INPUT_MODE: ${{ inputs.mode }}
         UPLOAD_LOCATION: ${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ github.workflow }}/
       run: |
+        set -euo pipefail
         echo "::group::$(printf '__________ %-100s' 'Process' | tr ' ' _)"
-        case "${{ inputs.mode }}" in
+        case "${INPUT_MODE}" in
           multi-upload)
             echo "Uploading files to S3 bucket..."
             first_line=true
             # Start the JSON object
-            echo "{" > ${{ github.workspace }}/presigned_urls.json
+            echo "{" > "${{ github.workspace }}/presigned_urls.json"
             while IFS= read -r file; do
               if [ -f "$file" ]; then
                 echo "Uploading $file..."
-                aws s3 cp "$file" s3://${{ inputs.s3_bucket }}/${{ env.UPLOAD_LOCATION }}
-                echo "Uploaded $file to s3://${{ inputs.s3_bucket }}/${{ env.UPLOAD_LOCATION }}"
+                aws s3 cp "$file" "s3://${INPUT_S3_BUCKET}/${UPLOAD_LOCATION}"
+                echo "Uploaded $file to s3://${INPUT_S3_BUCKET}/${UPLOAD_LOCATION}"
                 echo "Creating Pre-signed URL for $file..."
                 filename=$(basename "$file")
-                presigned_url="$(aws s3 presign s3://${{ inputs.s3_bucket }}/${{ env.UPLOAD_LOCATION }}$filename --expires-in 36000)"
+                presigned_url="$(aws s3 presign "s3://${INPUT_S3_BUCKET}/${UPLOAD_LOCATION}${filename}" --expires-in 36000)"
                 if [ "$first_line" = true ]; then
                   first_line=false
                 else
-                  echo "," >> ${{ github.workspace }}/presigned_urls.json
+                  echo "," >> "${{ github.workspace }}/presigned_urls.json"
                 fi
                 # Append the pre-signed URL to the file
-                echo " \"${filename}\": \"${presigned_url}\"" >> ${{ github.workspace }}/presigned_urls.json
+                echo " \"${filename}\": \"${presigned_url}\"" >> "${{ github.workspace }}/presigned_urls.json"
                 echo "Pre-signed URL for $file: $presigned_url"
               else
                 echo "Warning: $file does not exist or is not a regular file."
               fi
-            done < "${{ inputs.local_file }}"
+            done < "${INPUT_LOCAL_FILE}"
             # Close the JSON object
-            echo "}" >> ${{ github.workspace }}/presigned_urls.json
+            echo "}" >> "${{ github.workspace }}/presigned_urls.json"
             ;;
           single-upload)
             echo "Uploading single file to S3 bucket..."
-            aws s3 cp "${{ inputs.local_file }}" s3://${{ inputs.s3_bucket }}/${{ env.UPLOAD_LOCATION }}
-            echo "Uploaded ${{ inputs.local_file }} to s3://${{ inputs.s3_bucket }}/${{ env.UPLOAD_LOCATION }}"
-            filename=$(basename "${{ inputs.local_file }}")
-            echo "Creating Pre-signed URL for ${{ inputs.local_file }}..."
-            presigned_url="$(aws s3 presign s3://${{ inputs.s3_bucket }}/${{ env.UPLOAD_LOCATION }}${filename} --expires-in 36000)"
+            aws s3 cp "${INPUT_LOCAL_FILE}" "s3://${INPUT_S3_BUCKET}/${UPLOAD_LOCATION}"
+            echo "Uploaded ${INPUT_LOCAL_FILE} to s3://${INPUT_S3_BUCKET}/${UPLOAD_LOCATION}"
+            filename=$(basename "${INPUT_LOCAL_FILE}")
+            echo "Creating Pre-signed URL for ${INPUT_LOCAL_FILE}..."
+            presigned_url="$(aws s3 presign "s3://${INPUT_S3_BUCKET}/${UPLOAD_LOCATION}${filename}" --expires-in 36000)"
             echo "presigned_url=${presigned_url}" >> "$GITHUB_OUTPUT"
             ;;
           download)
             #Download The required file from s3
             echo "Downloading files from S3 bucket..."
-            aws s3 cp s3://${{ inputs.s3_bucket }}/${{ inputs.download_file }} .
+            aws s3 cp "s3://${INPUT_S3_BUCKET}/${INPUT_DOWNLOAD_FILE}" .
             ;;
           *)
             echo "Invalid mode. Use 'multi-upload', 'single-upload', or 'download'."


### PR DESCRIPTION
Avoid interpolating workflow inputs directly in bash commands in the composite action. Route input values through explicit environment variables and reference them as quoted shell variables inside the run script.

Quote S3 and workspace path arguments consistently and enable strict shell options with set -euo pipefail in the sync step. Preserve the existing upload, download, and presign behavior while reducing script-injection risk and satisfying code-scanning requirements.