### PR TITLE
Enable monthly sstate and shared download cache for CI builds

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -41,6 +41,10 @@ inputs:
     description: "PARALLEL_MAKE value used during builds (example: -j24)"
     required: false
     default: "-j24"
+  cache_root:
+    description: Host directory used to persist Yocto download and sstate caches
+    required: false
+    default: /mnt/yocto-cache/meta-audioreach
 
 runs:
   using: "composite"
@@ -63,20 +67,31 @@ runs:
       shell: bash
       run: |
         #!/bin/bash
-        set -e
+        set -euo pipefail
         filepath="${{ github.workspace }}/${{ env.MACHINE }}_${{ inputs.build_type }}_${{ env.ARTIFACT_KEY }}_file_list.txt"
         echo "filepath=${filepath}" >> $GITHUB_ENV
-        touch $filepath
-        USER_ID=$(id -u)
-        GROUP_ID=$(id -g)
+        touch "$filepath"
         USER=$(whoami)
         WORKSPACE=${{ github.workspace }}/..
         USER_HOME="/home/$USER"
+        CACHE_ROOT_INPUT="${{ inputs.cache_root }}"
+        CACHE_ROOT="${CACHE_ROOT_INPUT}"
+        if ! mkdir -p "${CACHE_ROOT}" 2>/dev/null; then
+          CACHE_ROOT="${WORKSPACE}/.yocto-cache/meta-audioreach"
+          mkdir -p "${CACHE_ROOT}"
+        fi
+        DOWNLOADS_DIR="${CACHE_ROOT}/downloads"
+        SSTATE_DIR="${CACHE_ROOT}/sstate-cache-$(date +%Y-%m)"
+        mkdir -p "${DOWNLOADS_DIR}" "${SSTATE_DIR}"
+        echo "CACHE_ROOT=${CACHE_ROOT}" >> "$GITHUB_ENV"
+        echo "DOWNLOADS_DIR=${DOWNLOADS_DIR}" >> "$GITHUB_ENV"
+        echo "SSTATE_DIR=${SSTATE_DIR}" >> "$GITHUB_ENV"
         echo "::group::$(printf '__________ %-100s' 'build' | tr ' ' _)"
         docker run \
           --rm \
           --user $(id -u):$(id -g) \
-          -v ${WORKSPACE}:${USER_HOME}/workspace \
+          -v "${WORKSPACE}:${USER_HOME}/workspace" \
+          -v "${CACHE_ROOT}:/yocto-cache" \
           -w ${USER_HOME}/workspace \
           --privileged \
           --cpus=${{ inputs.docker_cpus }} \
@@ -84,7 +99,10 @@ runs:
           --ulimit nofile=1048576:1048576 \
           ${{ inputs.docker_image }} \
           bash -c "
-            set -e
+            set -euo pipefail
+            export DL_DIR=/yocto-cache/downloads
+            export SSTATE_DIR=/yocto-cache/sstate-cache-$(date +%Y-%m)
+            export BB_ENV_PASSTHROUGH_ADDITIONS=\"\${BB_ENV_PASSTHROUGH_ADDITIONS:+\${BB_ENV_PASSTHROUGH_ADDITIONS} }DL_DIR SSTATE_DIR\"
             kas shell ${{ inputs.kas_file }} -c '
               umask 022
               export BB_NUMBER_THREADS=\"${{ inputs.bitbake_threads }}\"
@@ -193,3 +211,5 @@ runs:
         echo "- Config File: ${{ inputs.kas_file }}" >> $GITHUB_STEP_SUMMARY
         echo "- Build Type: ${{ inputs.build_type }}" >> $GITHUB_STEP_SUMMARY
         echo "- Build Command: ${{ inputs.build_command }}" >> $GITHUB_STEP_SUMMARY
+        echo "- Yocto downloads cache: ${{ env.DOWNLOADS_DIR }}" >> $GITHUB_STEP_SUMMARY
+        echo "- Yocto sstate cache: ${{ env.SSTATE_DIR }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on:
       group: GHA-Audioreach-SelfHosted-RG
       labels: [ self-hosted, audior-prd-u22-sdk-x64-large-od-ephem ]
+    env:
+      YOCTO_CACHE_ROOT: ${{ vars.YOCTO_CACHE_DIR || format('{0}/../.yocto-cache/meta-audioreach', github.workspace) }}
     strategy:
       fail-fast: false
       matrix:
@@ -46,6 +48,7 @@ jobs:
           build_command: ${{ matrix.build_matrix.build_commands[inputs.build_type] }}  # Get command from matrix based on build type
           build_type: ${{ inputs.build_type }}
           image_name: ${{ matrix.build_matrix.image_name }}
+          cache_root: ${{ env.YOCTO_CACHE_ROOT }}
         env:
           MACHINE: ${{ matrix.build_matrix.machine_name }}
 


### PR DESCRIPTION
Add cache_root support to the build composite action and mount that host path into the build container as /yocto-cache. Export DL_DIR and SSTATE_DIR before invoking kas so Yocto reuses downloads and sstate artifacts across runs.

Default the cache root from repository variable YOCTO_CACHE_DIR and fall back to a workspace-adjacent directory when the variable is not set. Create cache directories automatically and keep sstate segmented by month to align with the meta-qcom cache rotation pattern.