### PR TITLE
Enable monthly sstate and shared download cache for CI builds

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -82,10 +82,12 @@ runs:
         fi
         DOWNLOADS_DIR="${CACHE_ROOT}/downloads"
         SSTATE_DIR="${CACHE_ROOT}/sstate-cache-$(date +%Y-%m)"
-        mkdir -p "${DOWNLOADS_DIR}" "${SSTATE_DIR}"
+        BB_HASHSERVE_DB_DIR="${CACHE_ROOT}/hashserv-db"
+        mkdir -p "${DOWNLOADS_DIR}" "${SSTATE_DIR}" "${BB_HASHSERVE_DB_DIR}"
         echo "CACHE_ROOT=${CACHE_ROOT}" >> "$GITHUB_ENV"
         echo "DOWNLOADS_DIR=${DOWNLOADS_DIR}" >> "$GITHUB_ENV"
         echo "SSTATE_DIR=${SSTATE_DIR}" >> "$GITHUB_ENV"
+        echo "BB_HASHSERVE_DB_DIR=${BB_HASHSERVE_DB_DIR}" >> "$GITHUB_ENV"
         echo "::group::$(printf '__________ %-100s' 'build' | tr ' ' _)"
         docker run \
           --rm \
@@ -102,7 +104,8 @@ runs:
             set -euo pipefail
             export DL_DIR=/yocto-cache/downloads
             export SSTATE_DIR=/yocto-cache/sstate-cache-$(date +%Y-%m)
-            export BB_ENV_PASSTHROUGH_ADDITIONS=\"\${BB_ENV_PASSTHROUGH_ADDITIONS:+\${BB_ENV_PASSTHROUGH_ADDITIONS} }DL_DIR SSTATE_DIR\"
+            export BB_HASHSERVE_DB_DIR=/yocto-cache/hashserv-db
+            export BB_ENV_PASSTHROUGH_ADDITIONS=\"\${BB_ENV_PASSTHROUGH_ADDITIONS:+\${BB_ENV_PASSTHROUGH_ADDITIONS} }DL_DIR SSTATE_DIR BB_HASHSERVE_DB_DIR\"
             kas shell ${{ inputs.kas_file }} -c '
               umask 022
               export BB_NUMBER_THREADS=\"${{ inputs.bitbake_threads }}\"
@@ -213,3 +216,4 @@ runs:
         echo "- Build Command: ${{ inputs.build_command }}" >> $GITHUB_STEP_SUMMARY
         echo "- Yocto downloads cache: ${{ env.DOWNLOADS_DIR }}" >> $GITHUB_STEP_SUMMARY
         echo "- Yocto sstate cache: ${{ env.SSTATE_DIR }}" >> $GITHUB_STEP_SUMMARY
+        echo "- Yocto hashserve DB: ${{ env.BB_HASHSERVE_DB_DIR }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Add cache_root support to the build composite action and mount that host path into the build container as /yocto-cache. Export DL_DIR and SSTATE_DIR before invoking kas so Yocto reuses downloads and sstate artifacts across runs.

Default the cache root from repository variable YOCTO_CACHE_DIR and fall back to a workspace-adjacent directory when the variable is not set. Create cache directories automatically and keep sstate segmented by month to align with the meta-qcom cache rotation pattern.