### PR TITLE
audioreach-conf: srcrev bump cb9e696...e4de9ba

### DIFF
--- a/recipes/audioreach-conf/audioreach-conf_git.bb
+++ b/recipes/audioreach-conf/audioreach-conf_git.bb
@@ -1,10 +1,10 @@
 DESCRIPTION = "AudioReach configurations"
 HOMEPAGE = "https://github.com/Audioreach/audioreach-conf"
 
-LICENSE = "BSD-3-Clause-Clear"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=51110a366f598bc0b8f8e59141a18efb"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=849c526521c1203a789a87389d328892"
 
-SRCREV = "cb9e696b1c8c6d93090bb653b09a7d8a7aa2f80b"
+SRCREV = "e4de9ba743a43fb4430db083ce98fb8ccd37d2c6"
 PV = "1.0+git${SRCPV}"
 
 SRC_URI = "git://github.com/Audioreach/audioreach-conf.git;protocol=https;branch=master"


### PR DESCRIPTION
Update LICENSE and LIC_FILES_CHKSUM to match audioreach-conf licence.

Commits included in this version bump are below:

acdbdata : kvh2xml : add tag to set dynamic transition mode on FNN_NS module
Update license marking
Update copyright headers to reflect Qualcomm Technologies, Inc. kvh2xml: Add streamPP vad SG value
acdbdata: Add macros for 4 channels
CI: Disable armor checkers in qcom preflight workflow Update library version references in build files