### PR TITLE
CI: add base.lock.yml to pin upstream layer revisions

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -1,0 +1,20 @@
+header:
+    version: 14
+overrides:
+    repos:
+        oe-core:
+            commit: 42fa856a00ac16b2a7a83d7ecfa60a5be192b16c
+        bitbake:
+            commit: cb28befc56d201cace72d70891e731b955fb567f
+        meta-arm:
+            commit: f3a2db0561d60aa0401beefe783ee91c8ebb3bcb
+        meta-openembedded:
+            commit: 335045d3fb440cbb6de0716ffd7dd043bbd3f6ad
+        meta-virtualization:
+            commit: 4ba5825ee16fcded87f4d555b4ed7a7615dc67ac
+        meta-selinux:
+            commit: f7306d7af4425553684a860df6f6d0ee66efba31
+        meta-updater:
+            commit: a8af24357121dc8614fd98f234b73d55005b0cc9
+        meta-security:
+            commit: 9265f142f3890df2d00d71d13b19e95a082707ed


### PR DESCRIPTION
Add ci/base.lock.yml to lock all upstream Yocto meta layers to fixed commit revisions.

Pin oe-core, bitbake, meta-arm, meta-openembedded, meta-virtualization, meta-selinux, meta-updater, and meta-security to known-good commits.

Ensure reproducible CI builds and avoid breakages caused by tracking moving upstream branches.