### PR TITLE
audioreach-graphmgr: Add conditional alsa-lib dependency and package alsa-lib plugin library

### DIFF
--- a/recipes/audioreach-graphmgr/audioreach-graphmgr_git.bb
+++ b/recipes/audioreach-graphmgr/audioreach-graphmgr_git.bb
@@ -24,6 +24,8 @@ SOLIBS = ".so*"
 FILES_SOLIBSDEV = ""
 INSANE_SKIP:${PN} += "dev-so"
 
+FILES:${PN} += "${libdir}/alsa-lib/*"
+
 do_install:append () {
     if ${@bb.utils.contains('EXTRA_OECONF', '--with-no-ipc', 'false', 'true', d)}; then
     install -m 0644 ${UNPACKDIR}/agm_server.service -D ${D}${sysconfdir}/systemd/system/agm_server.service

--- a/recipes/audioreach-graphmgr/audioreach-graphmgr_git.bb
+++ b/recipes/audioreach-graphmgr/audioreach-graphmgr_git.bb
@@ -13,6 +13,7 @@ DEPENDS = "glib-2.0 tinyalsa audioreach-graphservices audioreach-conf"
 
 # Add dbus to DEPENDS only if --with-no-ipc is NOT in EXTRA_OECONF
 DEPENDS:append = "${@bb.utils.contains('EXTRA_OECONF', '--with-no-ipc', '', ' dbus', d)}"
+DEPENDS:append = "${@bb.utils.contains_any('EXTRA_OECONF', '--enable-alsalib --enable-alsalib=yes', ' alsa-lib', '', d)}"
 
 EXTRA_OECONF += "--with-glib --with-syslog"
 EXTRA_OECONF:append:qcom = " --with-no-ipc"


### PR DESCRIPTION
Add alsa-lib to DEPENDS only when the --enable-alsalib configuration option is enabled.

Add the alsa-lib plugin install path to FILES:${PN} to package alsa-lib plugin libraries.
