### PR TITLE
audioreach-conf: srcrev bump e4de9ba...a8c8cf1

### DIFF
--- a/recipes/audioreach-conf/audioreach-conf_git.bb
+++ b/recipes/audioreach-conf/audioreach-conf_git.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/Audioreach/audioreach-conf"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=849c526521c1203a789a87389d328892"
 
-SRCREV = "e4de9ba743a43fb4430db083ce98fb8ccd37d2c6"
+SRCREV = "a8c8cf1481534ef5ab74fdedf9aeaa1e69cf17de"
 PV = "1.0+git${SRCPV}"
 
 SRC_URI = "git://github.com/Audioreach/audioreach-conf.git;protocol=https;branch=master"

--- a/recipes/audioreach-conf/audioreach-conf_git.bb
+++ b/recipes/audioreach-conf/audioreach-conf_git.bb
@@ -18,3 +18,4 @@ inherit autotools pkgconfig
 do_compile[noexec] = "1"
 
 ALLOW_EMPTY:${PN} = "1"
+FILES:${PN} += "${datadir}/alsa/ucm2/conf.virt.d/*"


### PR DESCRIPTION
audioreach-conf: Include ALSAlib configuration files in package

audioreach-conf: srcrev bump e4de9ba...a8c8cf1

Commits included in this version bump are below:

audioreach-conf: Add --with-libalsa configure option
linux/reference: Add ALSA lib configuration files.