### PR TITLE
audioreach-graphmgr: Add conditional alsa-lib dependency and package alsa-lib plugin library

### DIFF
--- a/recipes/audioreach-graphmgr/audioreach-graphmgr_git.bb
+++ b/recipes/audioreach-graphmgr/audioreach-graphmgr_git.bb
@@ -21,6 +21,8 @@ SOLIBS = ".so*"
 FILES_SOLIBSDEV = ""
 INSANE_SKIP:${PN} += "dev-so"
 
+FILES:${PN} += "${libdir}/alsa-lib/*"
+
 do_install:append () {
     install -m 0644 ${WORKDIR}/agm_server.service -D ${D}${sysconfdir}/systemd/system/agm_server.service
     install -d ${D}${sysconfdir}/systemd/system/multi-user.target.wants/

--- a/recipes/audioreach-graphmgr/audioreach-graphmgr_git.bb
+++ b/recipes/audioreach-graphmgr/audioreach-graphmgr_git.bb
@@ -11,6 +11,7 @@ SRC_URI     += "file://agm-dbus.conf"
 S = "${WORKDIR}/git"
 
 DEPENDS = "glib-2.0 tinyalsa audioreach-graphservices dbus audioreach-conf"
+DEPENDS:append = "${@bb.utils.contains_any('EXTRA_OECONF', '--enable-alsalib --enable-alsalib=yes', ' alsa-lib', '', d)}"
 EXTRA_OECONF += "--with-glib --with-syslog"
 # tinyalsa uses dlopen() to load the unversioned AGM .so at runtime
 # (see tinyalsa/src/snd_card_plugin.c), so the unversioned .so must be


### PR DESCRIPTION
Add alsa-lib to DEPENDS only when the --enable-alsalib configuration option is enabled.

Add the alsa-lib plugin install path to FILES:${PN} to package alsa-lib plugin libraries.