### PR TITLE
CI: Replace git protocol with HTTPS for meta-raspberrypi repository

### DIFF
--- a/ci/raspberrypi4.yml
+++ b/ci/raspberrypi4.yml
@@ -29,7 +29,7 @@ repos:
       meta-poky:
 
   meta-raspberrypi:
-    url: git://git.yoctoproject.org/meta-raspberrypi
+    url: https://git.yoctoproject.org/meta-raspberrypi
 
   meta-openembedded:
     url: https://git.openembedded.org/meta-openembedded


### PR DESCRIPTION
Switch the repository URL from git:// to https:// to improve compatibility with firewalls and modern network restrictions.