### PR TITLE
CI: switch to nodistro, drop poky, update SHAs

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -3,18 +3,20 @@ header:
 overrides:
     repos:
         oe-core:
-            commit: 42fa856a00ac16b2a7a83d7ecfa60a5be192b16c
+            commit: 3724b93538d3acbec9f48d4c524b51d166071708
         bitbake:
-            commit: cb28befc56d201cace72d70891e731b955fb567f
+            commit: 2b47c2fc40b753e260b63ec419edfd1f85adff90
         meta-arm:
-            commit: f3a2db0561d60aa0401beefe783ee91c8ebb3bcb
+            commit: 1843e9e2eb983cfda6a025e7435c0b855aa94eeb
         meta-openembedded:
             commit: 335045d3fb440cbb6de0716ffd7dd043bbd3f6ad
         meta-virtualization:
-            commit: 4ba5825ee16fcded87f4d555b4ed7a7615dc67ac
+            commit: 022f4356d4a9b389f51472d40a9330aa59f6bb9a
         meta-selinux:
-            commit: f7306d7af4425553684a860df6f6d0ee66efba31
+            commit: 1ba26da4b9bec3f102bd831efe0db00c7d61f7f2
         meta-updater:
             commit: a8af24357121dc8614fd98f234b73d55005b0cc9
         meta-security:
             commit: 9265f142f3890df2d00d71d13b19e95a082707ed
+        meta-dpdk:
+            commit: c4e58978ce61c47c2f54206e07f9ad46be2ed257

--- a/ci/base.yml
+++ b/ci/base.yml
@@ -3,7 +3,7 @@
 header:
   version: 14
 
-distro: poky-altcfg
+distro: nodistro
 
 defaults:
   repos:
@@ -19,11 +19,6 @@ repos:
     url: https://github.com/openembedded/bitbake
     layers:
       .: excluded
-
-  meta-yocto:
-    url: https://git.yoctoproject.org/meta-yocto
-    layers:
-      meta-poky:
 
   meta-qcom:
     url: https://github.com/qualcomm-linux/meta-qcom.git
@@ -51,7 +46,7 @@ local_conf_header:
     IMAGE_CLASSES += "image_types_qcom"
     IMAGE_FSTYPES += "qcomflash"
   extra: |
-    DISTRO_FEATURES:append = " efi pni-names"
+    DISTRO_FEATURES:append = " efi pam pni-names"
     EXTRA_IMAGE_FEATURES = "allow-empty-password empty-root-password allow-root-login"
     IMAGE_ROOTFS_EXTRA_SPACE = "307200"
 

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -12,6 +12,10 @@ repos:
 
   meta-openembedded:
     url: https://github.com/openembedded/meta-openembedded
+    patches:
+      plain:
+        repo: meta-qcom
+        path: patches/meta-oe/0001-mariadb-fix-building-for-the-ARMv8.3-A-and-later-sys.patch
     layers:
       meta-filesystems:
       meta-gnome:


### PR DESCRIPTION
Switch CI base to use bitbake nodistro instead of poky-alt. Align configuration with nodistro as it now provides most of the features previously relied upon from poky-alt.

Drop the meta-poky layer as it is no longer required after the transition to nodistro.

Add 'pam' to DISTRO_FEATURES to match feature parity with poky-alt. This resolves missing dependency issues for weston-examples required by
initramfs-kerneltest-full-image:

Update layer revisions in ci/base.lock.yml to new commits across oe-core, bitbake, meta-arm, meta-virtualization, meta-selinux, and add meta-dpdk with pinned revision.