### PR TITLE
audioreach-graphservices: srcrev bump 65320f2...8445aee

### DIFF
--- a/recipes/audioreach-graphservices/audioreach-graphservices_git.bb
+++ b/recipes/audioreach-graphservices/audioreach-graphservices_git.bb
@@ -3,7 +3,7 @@ SUMMARY = "AudioReach Graph Service"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ef516c5438f1b599326a5e207572f477"
 
-SRCREV = "65320f2c38b2ee675ae674764b3932820551fb55"
+SRCREV = "8445aee939cb8b37d80eccf6b43baf778fef23c4"
 PV = "0.0+git"
 SRC_URI = "git://git@github.com/Audioreach/audioreach-graphservices.git;protocol=https;branch=master"
 


### PR DESCRIPTION
Commits included in this version bump are below:

2d09026 ats/adie: Ensure error code is logged in ATS_ERR messages
4a3dcf6 dls: Add changes to enable DLS running on ADSP
2e543d9 ar_osal/shmem: Handle posix_memalign return value
4e6b10d ar_osal/shmem: Fix sys_id type mismatch in
ar_shmem_validate_sys_id
e419c58 spf: api: Add miqster header file for audio zoom
c771c89 audio: mdsp: enable MDSP_PROC build flag
a54038d spf: Add new module api headers for offload spatial audio
feature
08ebe0a ar_osal: linux: Add generic physical shared memory allocator
afb4367 aml: Fix underflow crash caused by invalid delta file
b4281ee args: spf: update mma api to support synthetic detection
cd56461 ci: align stale workflow settings
4b952e8 args: Add VAD and SH_MEM module headers
