### PR TITLE
audioreach-kernel: srcrev bump bf478f8..664f553

### DIFF
--- a/recipes-kernel/audioreach-kernel/audioreach-kernel-headers_git.bb
+++ b/recipes-kernel/audioreach-kernel/audioreach-kernel-headers_git.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/AudioReach/audioreach-kernel"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d683615f65309f6c050cbd1bb2b3c575"
 
-SRCREV = "bf478f88d42068a9bd90cbd8162171acce8114d6"
+SRCREV = "664f553de5295ca95f1dfe41fa6fba00f6035d9c"
 PV = "0.0+git"
 SRC_URI = "git://github.com/AudioReach/audioreach-kernel.git;protocol=https;branch=master"
 

--- a/recipes-kernel/audioreach-kernel/audioreach-kernel_git.bb
+++ b/recipes-kernel/audioreach-kernel/audioreach-kernel_git.bb
@@ -10,7 +10,7 @@ SRC_URI = "git://github.com/AudioReach/audioreach-kernel.git;protocol=https;bran
            file://asoc-blacklist.conf \
            file://v1-0001-audioreach-driver-audioreach-common-Fix-WSA-Mute-.patch \
     "
-SRCREV = "bf478f88d42068a9bd90cbd8162171acce8114d6"
+SRCREV = "664f553de5295ca95f1dfe41fa6fba00f6035d9c"
 
 PV = "0.0+git"
 


### PR DESCRIPTION
Commits included in this version bump are below:

ed6d5c0 audioreach-driver: Enable RPMsg packet driver