### PR TITLE
audioreach-conf: srcrev bump a8c8cf1...7143e0f

### DIFF
--- a/recipes/audioreach-conf/audioreach-conf_git.bb
+++ b/recipes/audioreach-conf/audioreach-conf_git.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/Audioreach/audioreach-conf"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=849c526521c1203a789a87389d328892"
 
-SRCREV = "a8c8cf1481534ef5ab74fdedf9aeaa1e69cf17de"
+SRCREV = "7143e0fe9278b81de7276a372d4595fff36167e8"
 PV = "1.0+git${SRCPV}"
 
 SRC_URI = "git://github.com/Audioreach/audioreach-conf.git;protocol=https;branch=master"


### PR DESCRIPTION
Commits included in this version bump are below:

cb92359 nxp: Add ACDB and kvh2xml for NXP devices.
538bf0d Switch pre-merge workflow to pull_request and add LAVA trigger flow 
7143e0f acdbdata: add SMECNS modules and enable AIG use cases