### PR TITLE
audioreach-pal: srcrev bump 4a13cc4...2fa9b82

### DIFF
--- a/recipes/audioreach-pal/audioreach-pal_git.bb
+++ b/recipes/audioreach-pal/audioreach-pal_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=51110a366f598bc0b8f8e59141a18efb"
 SRCPROJECT = "git://github.com/AudioReach/audioreach-pal.git"
 SRCBRANCH  = "master"
 
-SRCREV = "4a13cc426171047b00de1ad8f76d058cba89c95a"
+SRCREV = "2fa9b824b68f8ab4f573301820aa3c06ce1e2c83"
 PV = "0.0+git"
 SRC_URI  = "${SRCPROJECT};protocol=https;branch=${SRCBRANCH}"
 


### PR DESCRIPTION
audioreach-pal: srcrev bump 4a13cc4...2fa9b82
Commits included in this version bump are below:

a981f94 pal: disable SoundDose support via SOUNDDOSE_UNSUPPORTED macro
8d9df0e PAL: restore exit log in pal_stream_close
0712e7d pal: proper file rename for resourcemanager_Shikra-CQM_EVK.xml
ae50223 library versioning across build artifacts
66f3aad CI: Add pre-merge workflows, checkers, and build scripts
c5b5c92 configs: Rename Shikra CQM/CQS EVK audio XML files to fix typo error
