### PR TITLE
Switch default builds to qcom-multimedia-proprietary-image

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -17,7 +17,7 @@ inputs:
   build_command:
     description: Command to run for the build
     required: false
-    default: "bitbake qcom-multimedia-image"
+    default: "bitbake qcom-multimedia-proprietary-image"
   build_type:
     description: Type of build to perform (flat_build or sdk_build)
     required: false
@@ -125,8 +125,8 @@ runs:
         else
           # For QCOM devices
           
-          cp "qcom-multimedia-image-${IMAGE_NAME}.rootfs.qcomflash.tar.gz" "$PUB_DIR/qcom-multimedia-image-${KAS_FILE}.rootfs.qcomflash.tar.gz"
-          echo "${PUB_DIR}/qcom-multimedia-image-${KAS_FILE}.rootfs.qcomflash.tar.gz" >> ${{ env.filepath }}
+          cp "qcom-multimedia-proprietary-image-${IMAGE_NAME}.rootfs.qcomflash.tar.gz" "$PUB_DIR/qcom-multimedia-proprietary-image-${KAS_FILE}.rootfs.qcomflash.tar.gz"
+          echo "${PUB_DIR}/qcom-multimedia-proprietary-image-${KAS_FILE}.rootfs.qcomflash.tar.gz" >> ${{ env.filepath }}
 
         fi
         

--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -152,7 +152,7 @@ runs:
 
         IMAGE_TYPE="core-image-base"
         if [ "${DISTRO_NAME}" = "qcom-distro" ]; then
-          IMAGE_TYPE="qcom-multimedia-image"
+          IMAGE_TYPE="qcom-multimedia-proprietary-image"
           echo "AUTO_LOGIN_PASSWORD_PROMPT=Password" >> "${VARS_OUT_PATH}/gh-variables.ini"
           echo "AUTO_LOGIN_PASSWORD=oelinux123"     >> "${VARS_OUT_PATH}/gh-variables.ini"
         fi

--- a/.github/actions/loading/action.yml
+++ b/.github/actions/loading/action.yml
@@ -87,8 +87,8 @@ runs:
                 image_name: selector,
                 testing_enabled: true,
                 build_commands: {
-                  flat_build: 'bitbake qcom-multimedia-image',
-                  sdk_build: 'bitbake qcom-multimedia-image && bitbake qcom-multimedia-image -c populate_sdk'
+                  flat_build: 'bitbake qcom-multimedia-proprietary-image',
+                  sdk_build: 'bitbake qcom-multimedia-proprietary-image && bitbake qcom-multimedia-proprietary-image -c populate_sdk'
                 }
               });
             } else if (Array.isArray(value)) {

--- a/ci/MACHINES.json
+++ b/ci/MACHINES.json
@@ -5,8 +5,8 @@
     "image_name": "iq-8275-evk",
     "testing_enabled": false,
     "build_commands": {
-      "flat_build": "bitbake qcom-multimedia-image",
-      "sdk_build": "bitbake qcom-multimedia-image && bitbake qcom-multimedia-image -c populate_sdk"
+      "flat_build": "bitbake qcom-multimedia-proprietary-image",
+      "sdk_build": "bitbake qcom-multimedia-proprietary-image && bitbake qcom-multimedia-proprietary-image -c populate_sdk"
     }
   },
   "9075-evk": {
@@ -15,8 +15,8 @@
     "image_name": "iq-9075-evk",
     "testing_enabled": false,
     "build_commands": {
-      "flat_build": "bitbake qcom-multimedia-image",
-      "sdk_build": "bitbake qcom-multimedia-image && bitbake qcom-multimedia-image -c populate_sdk"
+      "flat_build": "bitbake qcom-multimedia-proprietary-image",
+      "sdk_build": "bitbake qcom-multimedia-proprietary-image && bitbake qcom-multimedia-proprietary-image -c populate_sdk"
     }
   },
   "rb3gen2-core-kit": {
@@ -25,8 +25,8 @@
     "image_name": "rb3gen2-core-kit",
     "testing_enabled": true,
 	"build_commands": {
-      "flat_build": "bitbake qcom-multimedia-image",
-      "sdk_build": "bitbake qcom-multimedia-image && bitbake qcom-multimedia-image -c populate_sdk"
+      "flat_build": "bitbake qcom-multimedia-proprietary-image",
+      "sdk_build": "bitbake qcom-multimedia-proprietary-image && bitbake qcom-multimedia-proprietary-image -c populate_sdk"
     }
   },
   "rb3gen2-core-kit-6.18": {
@@ -35,8 +35,8 @@
     "image_name": "rb3gen2-core-kit",
     "testing_enabled": true,
 	"build_commands": {
-      "flat_build": "bitbake qcom-multimedia-image",
-      "sdk_build": "bitbake qcom-multimedia-image && bitbake qcom-multimedia-image -c populate_sdk"
+      "flat_build": "bitbake qcom-multimedia-proprietary-image",
+      "sdk_build": "bitbake qcom-multimedia-proprietary-image && bitbake qcom-multimedia-proprietary-image -c populate_sdk"
     }
   },
   "raspberrypi4": {
@@ -55,8 +55,8 @@
     "image_name": "kaanapali-mtp",
     "testing_enabled": false,
     "build_commands": {
-      "flat_build": "bitbake qcom-multimedia-image",
-      "sdk_build": "bitbake qcom-multimedia-image && bitbake qcom-multimedia-image -c populate_sdk"
+      "flat_build": "bitbake qcom-multimedia-proprietary-image",
+      "sdk_build": "bitbake qcom-multimedia-proprietary-image && bitbake qcom-multimedia-proprietary-image -c populate_sdk"
     }
   },
   "sm8750-mtp": {
@@ -65,8 +65,8 @@
     "image_name": "sm8750-mtp",
     "testing_enabled": false,
     "build_commands": {
-      "flat_build": "bitbake qcom-multimedia-image",
-      "sdk_build": "bitbake qcom-multimedia-image && bitbake qcom-multimedia-image -c populate_sdk"
+      "flat_build": "bitbake qcom-multimedia-proprietary-image",
+      "sdk_build": "bitbake qcom-multimedia-proprietary-image && bitbake qcom-multimedia-proprietary-image -c populate_sdk"
     }
   }
 }

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -49,4 +49,4 @@ local_conf_header:
     SKIP_META_VIRT_SANITY_CHECK = "1"
 
 target:
-  - qcom-multimedia-image
+  - qcom-multimedia-proprietary-image


### PR DESCRIPTION
Switch all CI builds and test configurations to use qcom-multimedia-proprietary-image instead of
qcom-multimedia-image.

Update default build command in GitHub build action to use the proprietary image.

Modify artifact copy and publish logic to reflect new image naming for QCOM targets.

Update LAVA test plan configuration to use the proprietary image for qcom-distro.

Replace build commands in MACHINES.json across all supported QCOM targets for both flat and SDK builds.