### PR TITLE
audioreach-pipewire-plugin: srcrev bump c8de0e0..f7eec1c

### DIFF
--- a/recipes/audioreach-pipewire-plugin/audioreach-pipewire-plugin_git.bb
+++ b/recipes/audioreach-pipewire-plugin/audioreach-pipewire-plugin_git.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "Pipewire plugin for AudioReach to enable PAL card integration and
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=91f36d19ef812a054b22d918288de2b5"
 
-SRCREV = "c8de0e00c76efcb023e8d4e1e2d1d25881cf4701"
+SRCREV = "f7eec1c5e5aae9be82afab2aac2f4670d674a93b"
 PV = "0.0+git"
 SRC_URI = "git://github.com/AudioReach/audioreach-pipewire-plugin.git;protocol=https;branch=master"
 


### PR DESCRIPTION
Commits included in this version bump are below:
f7eec1c Merge pull request https://github.com/AudioReach/meta-audioreach/pull/29 from qti-sbojja/log_remove
ae432ea pipewire-plugin: remove noisy buffer read debug log
b30e9ed Revert "pipewire-plugin: Add initial Debian packaging metadata"
d424dfb CI: Refactor pre-merge workflows and integrate LAVA trigger flow
e03117e pipewire-plugin: Remove legacy SSMD playback filter
de386fd CI: Add checkers and pre-merge workflows
1d47989 pipewire-plugin: Add single-stream multi-device playback support