### PR TITLE
audioreach-graphmgr: add tinycompress dependency

### DIFF
--- a/recipes/audioreach-graphmgr/audioreach-graphmgr_git.bb
+++ b/recipes/audioreach-graphmgr/audioreach-graphmgr_git.bb
@@ -10,6 +10,7 @@ SRC_URI     += "file://agm_server.service"
 SRC_URI     += "file://agm-dbus.conf"
 
 DEPENDS = "glib-2.0 tinyalsa audioreach-graphservices audioreach-conf"
+DEPENDS:append:qcom = " tinycompress"
 
 # Add dbus to DEPENDS only if --with-no-ipc is NOT in EXTRA_OECONF
 DEPENDS:append = "${@bb.utils.contains('EXTRA_OECONF', '--with-no-ipc', '', ' dbus', d)}"


### PR DESCRIPTION
Ensure compress offload builds with tinycompress headers. Support AGM-backed compressed playback path.