### PR TITLE
Revert applying MariaDB ARMv8.3+ build fix patch in qcom-distro and pin Yocto dependencies from lockfile

### DIFF
--- a/.github/workflows/yocto-layer-check.yml
+++ b/.github/workflows/yocto-layer-check.yml
@@ -21,15 +21,34 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gawk wget git-core diffstat unzip texinfo gcc build-essential \
             chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping \
-            python3-git python3-jinja2 libegl-mesa0 libsdl1.2-dev pylint
+            python3-git python3-jinja2 python3-yaml libegl-mesa0 libsdl1.2-dev pylint
 
       - name: Poky Setup 
         run: |
+          set -euo pipefail
           cd ..
-          git clone https://git.openembedded.org/bitbake
-          git clone https://git.yoctoproject.org/meta-yocto
-          git clone https://git.openembedded.org/openembedded-core
-          git clone https://git.openembedded.org/meta-openembedded
+
+          python3 - <<'PY'
+          import subprocess
+          import urllib.request
+          import yaml
+
+          lock_url = "https://raw.githubusercontent.com/qualcomm-linux/meta-qcom/master/ci/base.lock.yml"
+          with urllib.request.urlopen(lock_url) as f:
+              lock = yaml.safe_load(f.read().decode("utf-8"))
+
+          commits = lock["overrides"]["repos"]
+
+          repos = {
+              "bitbake": ("https://github.com/openembedded/bitbake", commits["bitbake"]["commit"]),
+              "openembedded-core": ("https://github.com/openembedded/openembedded-core", commits["oe-core"]["commit"]),
+              "meta-openembedded": ("https://github.com/openembedded/meta-openembedded", commits["meta-openembedded"]["commit"]),
+          }
+
+          for directory, (url, commit) in repos.items():
+              subprocess.run(["git", "clone", url, directory], check=True)
+              subprocess.run(["git", "-C", directory, "checkout", commit], check=True)
+          PY
 
       - name: Source Environment and Run Layer Check
         run: |

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -22,7 +22,7 @@ repos:
       meta-xfce:
 
   meta-virtualization:
-    url: https://git.yoctoproject.org/git/meta-virtualization
+    url: https://git.yoctoproject.org/meta-virtualization
     branch: master
 
   meta-selinux:

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -12,10 +12,6 @@ repos:
 
   meta-openembedded:
     url: https://github.com/openembedded/meta-openembedded
-    patches:
-      plain:
-        repo: meta-qcom
-        path: patches/meta-oe/0001-mariadb-fix-building-for-the-ARMv8.3-A-and-later-sys.patch
     layers:
       meta-filesystems:
       meta-gnome:


### PR DESCRIPTION
Commit included:
Revert applying MariaDB ARMv8.3+ build fix patch in qcom-distro.
CI: pin Yocto dependencies from lockfile
ci/qcom-distro: update the URL for meta-virtualization