### PR TITLE
Fix Buildx GHA cache collisions in PR builds

### DIFF
--- a/.github/actions/build_docker_image/action.yml
+++ b/.github/actions/build_docker_image/action.yml
@@ -1,6 +1,11 @@
 name: Build Docker Image
 description: Build Docker Image Action
 
+inputs:
+  cache_scope:
+    description: Unique cache scope for Buildx gha cache
+    required: true
+
 outputs:
   image_name:
     description: Name of the built Docker image
@@ -43,8 +48,8 @@ runs:
           "USER=${{ steps.pre-build.outputs.user }}"
           "UID=${{ steps.pre-build.outputs.uid }}"
           "GID=${{ steps.pre-build.outputs.gid }}"
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=gha,scope=${{ inputs.cache_scope }}
+        cache-to: type=gha,mode=max,scope=${{ inputs.cache_scope }}
 
     - name: Post-Build Docker Image
       id: post-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,10 @@ on:
         default: "flat_build"
         description: Type of build to perform (flat_build or sdk_build)
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   build:
     runs-on:
@@ -26,6 +30,8 @@ jobs:
       - name: Build docker Image
         id: get-docker-image
         uses: Audioreach/meta-audioreach/.github/actions/build_docker_image@master
+        with:
+          cache_scope: ar-image-${{ github.event.pull_request.number || github.ref_name }}-${{ matrix.build_matrix.machine_name }}
 
       - name: Sync Codebase
         id: sync


### PR DESCRIPTION
## Summary
- add explicit `actions: write` permission in reusable build workflow for GHA cache writes
- pass a unique cache scope from workflow to composite action
- scope Buildx GHA cache by PR number (fallback to ref name) + machine name

## Why
PR runs currently share a global Buildx GHA cache scope, which causes intermittent `failed to reserve cache` errors during cache export.

## Validation
- compared failing and passing logs; only deterministic failure point was `exporting to GitHub Actions Cache`
- no functional build logic changed
