### PR TITLE
Use mode=min and ignore cache export failures in Docker build

### DIFF
--- a/.github/actions/build_docker_image/action.yml
+++ b/.github/actions/build_docker_image/action.yml
@@ -44,7 +44,7 @@ runs:
           "UID=${{ steps.pre-build.outputs.uid }}"
           "GID=${{ steps.pre-build.outputs.gid }}"
         cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-to: type=gha,mode=min,ignore-error=true
 
     - name: Post-Build Docker Image
       id: post-build

--- a/ci/base.yml
+++ b/ci/base.yml
@@ -9,6 +9,7 @@ defaults:
   repos:
     branch: master
 
+
 repos:
   oe-core:
     url: https://github.com/openembedded/openembedded-core


### PR DESCRIPTION
## Summary
- change Buildx GHA cache export from `mode=max` to `mode=min`
- add `ignore-error=true` for cache export

## Why
Reduce cache export size/pressure and prevent CI failure when GHA cache upload cannot reserve space.

## Change Scope
- only one line changed in `.github/actions/build_docker_image/action.yml`
