### PR TITLE
Switch Buildx GHA cache export to min and ignore errors

### DIFF
--- a/.github/actions/build_docker_image/action.yml
+++ b/.github/actions/build_docker_image/action.yml
@@ -44,7 +44,7 @@ runs:
           "UID=${{ steps.pre-build.outputs.uid }}"
           "GID=${{ steps.pre-build.outputs.gid }}"
         cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-to: type=gha,mode=min,ignore-error=true
 
     - name: Post-Build Docker Image
       id: post-build


### PR DESCRIPTION
Change Buildx GHA cache export from mode=max to mode=min Add ignore-error=true for cache export.

Reduce cache export size/pressure and prevent CI
failure when GHA cache upload cannot reserve space.